### PR TITLE
Added test case that was missing for :any application specification

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rabbit_feed (1.0.1)
+    rabbit_feed (1.0.2)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)

--- a/example/non_rails_app/Gemfile.lock
+++ b/example/non_rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (1.0.0)
+    rabbit_feed (1.0.2)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)

--- a/example/rails_app/Gemfile.lock
+++ b/example/rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (1.0.0)
+    rabbit_feed (1.0.2)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)

--- a/lib/rabbit_feed/event_routing.rb
+++ b/lib/rabbit_feed/event_routing.rb
@@ -55,7 +55,6 @@ module RabbitFeed
       end
 
       def handle_event event
-        (raise_routing_error event) unless (handles_event? event)
         event_rule = events[event.name]
         event_rule.handle_event event
       end
@@ -91,7 +90,7 @@ module RabbitFeed
 
     def handle_event event
       application = find_application event
-      (raise_routing_error event) unless application.present?
+      raise RoutingError.new "No routing defined for application with name: #{event.application} for events named: #{event.name}" unless application.present?
       application.handle_event event
     end
 
@@ -114,10 +113,6 @@ module RabbitFeed
     def find_application event
       name = event.application
       [named_applications[name], catch_all_application].compact.detect{|application| application.handles_event? event }
-    end
-
-    def raise_routing_error event
-      raise RoutingError.new "No routing defined for application with name: #{event.application} for events named: #{event.name}"
     end
   end
 end

--- a/lib/rabbit_feed/event_routing.rb
+++ b/lib/rabbit_feed/event_routing.rb
@@ -111,8 +111,10 @@ module RabbitFeed
     end
 
     def find_application event
-      name = event.application
-      [named_applications[name], catch_all_application].compact.detect{|application| application.handles_event? event }
+      candidate_applications = [named_applications[event.application], catch_all_application].compact
+      candidate_applications.detect do |application|
+        application.handles_event? event
+      end
     end
   end
 end

--- a/lib/rabbit_feed/version.rb
+++ b/lib/rabbit_feed/version.rb
@@ -1,3 +1,3 @@
 module RabbitFeed
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end

--- a/spec/lib/rabbit_feed/event_routing_spec.rb
+++ b/spec/lib/rabbit_feed/event_routing_spec.rb
@@ -43,6 +43,7 @@ module RabbitFeed
       events = [
         double(:event, application: 'dummy_1', name: 'event_1', payload: 1),
         double(:event, application: 'dummy_1', name: 'event_2', payload: 2),
+        double(:event, application: 'dummy_1', name: 'event_4', payload: 4),
         double(:event, application: 'dummy_2', name: 'event_3', payload: 3),
         double(:event, application: 'none',    name: 'event_4', payload: 4),
       ]


### PR DESCRIPTION
The problem was that if there was an existing application specification for an event that was not handled by the existing application specification, but is handled within an :any specification, it wouldn't actually get picked up by the :any specification.

@calo81 @dawid-sklodowski  Could you please sign off?