### PR TITLE
Provide the ability to accept any event

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rabbit_feed (2.0.0)
+    rabbit_feed (2.1.0)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)

--- a/README.md
+++ b/README.md
@@ -308,6 +308,26 @@ When the consumer is started, it will create its queue named using this pattern:
 
 _Note: The consumer queues will automatically expire (delete) after 7 days without any consumer connections. This is to prevent unused queues from hanging around once their associated consumer has been terminated._
 
+### Wildcards
+
+Applications that wish to handle events from any application or wish to handle any event can achieve this using the `:any` key.
+
+For example, the following would consume any event published by RabbitFeed:
+
+```ruby
+EventRouting do
+  accept_from(:any) do
+    event(:any) do |event|
+      puts event.payload
+    end
+  end
+end
+```
+
+In this example, the consumer queue will bind to the specified exchange on the following routing keys:
+
+    environment.*.*
+
 ## Delivery Semantics
 
 RabbitFeed provides 'at least once' delivery semantics. There are two use-cases where an event may be delivered more than once:

--- a/example/non_rails_app/Gemfile.lock
+++ b/example/non_rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.0.0)
+    rabbit_feed (2.1.0)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)

--- a/example/rails_app/Gemfile.lock
+++ b/example/rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.0.0)
+    rabbit_feed (2.1.0)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)

--- a/lib/rabbit_feed/version.rb
+++ b/lib/rabbit_feed/version.rb
@@ -1,3 +1,3 @@
 module RabbitFeed
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end


### PR DESCRIPTION
Consumers can now specify to receive any event from any application.

We'll need this feature to allow us to create a consumer that consumes all new types of events automatically (ie. for [Aerie](https://trello.com/c/CSzCQ5LT/209-13-epic-server-side-events-into-aerie)).

@sparrovv @calo81 @pvdb @danisola @dawid-sklodowski @tpaul09 Could you please sign off?