### PR TITLE
Redactions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rabbit_feed (2.1.1)
+    rabbit_feed (2.1.2)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)

--- a/lib/rabbit_feed/event.rb
+++ b/lib/rabbit_feed/event.rb
@@ -74,11 +74,9 @@ module RabbitFeed
     private
 
     def sensitive_proof_payload
-      clean_payload = payload.dup
-      sensitive_fields.each do |field|
+      sensitive_fields.each_with_object(payload.dup) do |field, clean_payload|
         clean_payload[field] = "[REMOVED]" if clean_payload.key?(field)
       end
-      clean_payload
     end
 
     def validate!

--- a/lib/rabbit_feed/event.rb
+++ b/lib/rabbit_feed/event.rb
@@ -4,15 +4,16 @@ module RabbitFeed
 
     SCHEMA_VERSION = '2.0.0'
 
-    attr_reader :schema, :payload, :metadata
+    attr_reader :schema, :payload, :metadata, :sensitive_fields
     validates :metadata, presence: true
     validates :payload, length: { minimum: 0, allow_nil: false, message: 'can\'t be nil' }
     validate  :required_metadata
 
-    def initialize metadata, payload={}, schema=nil
+    def initialize metadata, payload={}, schema=nil, sensitive_fields=[]
       @schema   = schema
       @payload  = payload.with_indifferent_access if payload
       @metadata = metadata.with_indifferent_access if metadata
+      @sensitive_fields = Array(sensitive_fields).map(&:to_s).flatten
       validate!
     end
 
@@ -22,6 +23,8 @@ module RabbitFeed
       writer << { 'metadata' => metadata, 'payload' => payload }
       writer.close
       buffer.string
+    rescue Avro::IO::AvroTypeError => e
+      raise Avro::IO::AvroTypeError.new(schema, sensitive_proof_payload)
     end
 
     def application
@@ -69,6 +72,14 @@ module RabbitFeed
     end
 
     private
+
+    def sensitive_proof_payload
+      clean_payload = payload.dup
+      @sensitive_fields.each do |field|
+        clean_payload[field] = "[REMOVED]" if clean_payload.key?(field)
+      end
+      clean_payload
+    end
 
     def validate!
       raise Error.new "Invalid event: #{errors.messages}" if invalid?

--- a/lib/rabbit_feed/event.rb
+++ b/lib/rabbit_feed/event.rb
@@ -75,7 +75,7 @@ module RabbitFeed
 
     def sensitive_proof_payload
       clean_payload = payload.dup
-      @sensitive_fields.each do |field|
+      sensitive_fields.each do |field|
         clean_payload[field] = "[REMOVED]" if clean_payload.key?(field)
       end
       clean_payload

--- a/lib/rabbit_feed/event.rb
+++ b/lib/rabbit_feed/event.rb
@@ -23,7 +23,7 @@ module RabbitFeed
       writer << { 'metadata' => metadata, 'payload' => payload }
       writer.close
       buffer.string
-    rescue Avro::IO::AvroTypeError => e
+    rescue Avro::IO::AvroTypeError
       raise Avro::IO::AvroTypeError.new(schema, sensitive_proof_payload)
     end
 

--- a/lib/rabbit_feed/event_definitions.rb
+++ b/lib/rabbit_feed/event_definitions.rb
@@ -28,7 +28,7 @@ module RabbitFeed
     class Event
       include ActiveModel::Validations
 
-      attr_reader :name, :definition, :version, :fields
+      attr_reader :name, :definition, :version, :fields, :sensitive_fields
       validates_presence_of :name, :definition, :version
       validate :schema_parseable
       validates :version, format: { with: /\A\d+\.\d+\.\d+\z/, message: 'must be in *.*.* format' }
@@ -37,6 +37,7 @@ module RabbitFeed
         @name    = name
         @version = version
         @fields  = []
+        @sensitive_fields = []
       end
 
       def payload_contains &block
@@ -44,6 +45,7 @@ module RabbitFeed
       end
 
       def field name, options
+        @sensitive_fields << name.to_s if options.delete(:sensitive)
         fields << (Field.new name, options[:type], options[:definition])
       end
 

--- a/lib/rabbit_feed/event_definitions.rb
+++ b/lib/rabbit_feed/event_definitions.rb
@@ -45,7 +45,7 @@ module RabbitFeed
       end
 
       def field name, options
-        @sensitive_fields << name.to_s if options.delete(:sensitive)
+        sensitive_fields << name.to_s if options.delete(:sensitive)
         fields << (Field.new name, options[:type], options[:definition])
       end
 

--- a/lib/rabbit_feed/producer.rb
+++ b/lib/rabbit_feed/producer.rb
@@ -9,7 +9,7 @@ module RabbitFeed
       event_definition = event_definitions[name] or raise (Error.new "definition for event: #{name} not found")
       timestamp        = Time.now.utc
       metadata         = (metadata event_definition.version, name, timestamp)
-      event            = Event.new metadata, payload, event_definition.schema
+      event            = Event.new metadata, payload, event_definition.schema, event_definition.sensitive_fields
       ProducerConnection.publish event.serialize, (options name, timestamp)
       event
     end

--- a/lib/rabbit_feed/version.rb
+++ b/lib/rabbit_feed/version.rb
@@ -1,3 +1,3 @@
 module RabbitFeed
-  VERSION = '2.1.1'
+  VERSION = '2.1.2'
 end

--- a/spec/lib/rabbit_feed/event_definitions_spec.rb
+++ b/spec/lib/rabbit_feed/event_definitions_spec.rb
@@ -10,8 +10,8 @@ module RabbitFeed
           end
           payload_contains do
             field('customer_id', type: 'string', definition: 'The definition of the customer id')
-            field('policy_id', type: 'string', definition: 'The definition of the policy id')
-            field('price', type: 'string', definition: 'The definition of the price')
+            field('policy_id', type: 'string', definition: 'The definition of the policy id', sensitive: true)
+            field('price', type: 'string', definition: 'The definition of the price', sensitive: true)
           end
         end
       end
@@ -21,6 +21,7 @@ module RabbitFeed
     it { should_not be_nil }
     it { should be_valid }
     its(:name) { should eq 'customer_purchases_policy' }
+    its(:sensitive_fields) { should match_array(['price', 'policy_id']) }
 
     describe EventDefinitions::Event do
       let(:name)       { 'event_name' }

--- a/spec/lib/rabbit_feed/event_spec.rb
+++ b/spec/lib/rabbit_feed/event_spec.rb
@@ -79,7 +79,10 @@ module RabbitFeed
                 type: {
                   name: 'event_payload',
                   type: 'record',
-                  fields: [{ name: 'event_field', type: 'int' }],
+                  fields: [
+                    { name: 'event_integer', type: 'int' },
+                    { name: 'event_string',  type: 'string' },
+                  ],
                 },
               },
               {
@@ -96,7 +99,11 @@ module RabbitFeed
       end
 
       context 'with invalid payload' do
-        let(:payload)  { { 'event_field' => 'INCORRECT' } }
+        let(:payload)  { {
+          'event_string'  => 'HIGHLY SENSITIVE',
+          'event_integer' => 'incorrect',
+        } }
+
         it 'raises an Exception' do
           expect {
             subject.serialize
@@ -104,7 +111,7 @@ module RabbitFeed
         end
 
         it 'can remove values from exception' do
-          event = described_class.new(metadata, payload, schema, ['event_field'])
+          event = described_class.new(metadata, payload, schema, ['event_string'])
           exception_msg = nil
           begin
             event.serialize
@@ -113,7 +120,8 @@ module RabbitFeed
           end
           expect(exception_msg).to_not be_nil
           expect(exception_msg).to_not include("INCORRECT")
-          expect(exception_msg).to include('{"event_field"=>"[REMOVED]"}')
+          expect(exception_msg).to include('"event_string"=>"[REMOVED]"')
+          expect(exception_msg).to include('"event_integer"=>"incorrect"')
         end
       end
     end

--- a/spec/lib/rabbit_feed/producer_spec.rb
+++ b/spec/lib/rabbit_feed/producer_spec.rb
@@ -12,7 +12,7 @@ module RabbitFeed
               'The definition of the event'
             end
             payload_contains do
-              field('field', type: 'string', definition: 'The definition of the field')
+              field('field', type: 'string', definition: 'The definition of the field', sensitive: true)
             end
           end
         end
@@ -37,6 +37,10 @@ module RabbitFeed
 
       it 'returns the event' do
         expect(subject).to be_a Event
+      end
+
+      it 'sets the sensitive fields for the event' do
+        expect(subject.sensitive_fields).to match_array(['field'])
       end
 
       it 'sets the event metadata' do


### PR DESCRIPTION
@joshuafleck @waynemoore 

This adds support to mark certain fields as _sensitive_ which will remove the value in the Exception and instead display "[REMOVED]"

```ruby
EventDefinitions do
  define_event('foobar', version: '1.0.0') do
    # ...
    field('customer_password', type: 'string', definition: 'super secret', sensitive: true)
  end
end
```