### PR TITLE
Allow specification of multiple hosts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rabbit_feed (2.1.2)
+    rabbit_feed (2.1.3)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)
@@ -12,10 +12,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.0)
-      activesupport (= 4.2.0)
+    activemodel (4.2.1)
+      activesupport (= 4.2.1)
       builder (~> 3.1)
-    activesupport (4.2.0)
+    activesupport (4.2.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -34,7 +34,7 @@ GEM
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.0)
     columnize (0.9.0)
-    connection_pool (2.1.2)
+    connection_pool (2.1.3)
     debug_inspector (0.0.2)
     debugger (1.6.8)
       columnize (>= 0.3.1)
@@ -52,7 +52,7 @@ GEM
       json
     json (1.8.2)
     method_source (0.8.2)
-    minitest (5.5.1)
+    minitest (5.7.0)
     multi_json (1.10.1)
     pidfile (0.3.0)
     pry (0.10.1)
@@ -107,7 +107,7 @@ GEM
       simplecov-html (~> 0.9.0)
     simplecov-html (0.9.0)
     slop (3.6.0)
-    thread_safe (0.3.4)
+    thread_safe (0.3.5)
     timecop (0.7.3)
     turnip (1.2.4)
       gherkin (>= 2.5)
@@ -128,3 +128,6 @@ DEPENDENCIES
   rspec-its
   rutabaga
   timecop
+
+BUNDLED WITH
+   1.10.5

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add this line to your application's Gemfile:
 
 ### Configuration
 
-Create a `config/rabbit_feed.yml` file. The following options can be specified:
+Create a `config/rabbit_feed.yml` file. The following options should be specified:
 
     environment:
       host: RabbitMQ host
@@ -35,6 +35,24 @@ Sample:
       user: guest
       password: guest
       application: beavers
+
+Configuration options that can be specified are:
+
+| Name | Use |
+| ---- | --- |
+| `host` | Hostname or IP of the RabbitMQ server |
+| `hosts` | Array of hostnames or IPs of a RabbitMQ cluster |
+| `port` | The port to use on the RabbitMQ server |
+| `user` | The user to authenticate with the RabbitMQ server |
+| `password` | The password to authenticate with the RabbitMQ server |
+| `application` | The name of the application - used for routing events to the specified consumers |
+| `environment` | The environment of the application - used for routing events to the specified consumers |
+| `exchange` | The name of the RabbitMQ exchange to which events are published |
+| `heartbeat` | The interval at which to send heartbeats to the RabbitMQ server (in seconds) |
+| `connect_timeout` | The timeout (in seconds) for connecting to the RabbitMQ server |
+| `network_recovery_interval` | Recovery interval (in seconds) periodic network recovery will use |
+| `auto_delete_queue` | If true, any queues created will auto-delete upon disconnect |
+| `auto_delete_exchange` | If true, any exchanges created will auto-delete upon disconnect |
 
 ### Initialisation
 

--- a/example/non_rails_app/Gemfile.lock
+++ b/example/non_rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.1.1)
+    rabbit_feed (2.1.3)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)
@@ -12,10 +12,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.0)
-      activesupport (= 4.2.0)
+    activemodel (4.2.1)
+      activesupport (= 4.2.1)
       builder (~> 3.1)
-    activesupport (4.2.0)
+    activesupport (4.2.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -27,12 +27,12 @@ GEM
     builder (3.2.2)
     bunny (1.7.0)
       amq-protocol (>= 1.9.2)
-    connection_pool (2.1.2)
+    connection_pool (2.1.3)
     diff-lcs (1.2.5)
     i18n (0.7.0)
-    json (1.8.2)
-    minitest (5.5.1)
-    multi_json (1.11.0)
+    json (1.8.3)
+    minitest (5.7.0)
+    multi_json (1.11.1)
     pidfile (0.3.0)
     rake (10.4.2)
     rspec (3.2.0)
@@ -48,7 +48,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.1)
-    thread_safe (0.3.4)
+    thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
 
@@ -59,3 +59,6 @@ DEPENDENCIES
   rabbit_feed!
   rake
   rspec
+
+BUNDLED WITH
+   1.10.5

--- a/example/rails_app/Gemfile.lock
+++ b/example/rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.1.1)
+    rabbit_feed (2.1.3)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)
@@ -61,7 +61,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1)
-    connection_pool (2.1.2)
+    connection_pool (2.1.3)
     diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.3.0)
@@ -189,3 +189,6 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   unicorn
+
+BUNDLED WITH
+   1.10.5

--- a/lib/rabbit_feed/configuration.rb
+++ b/lib/rabbit_feed/configuration.rb
@@ -2,13 +2,14 @@ module RabbitFeed
   class Configuration
     include ActiveModel::Validations
 
-    attr_reader :host, :port, :user, :password, :application, :environment, :exchange, :pool_size, :pool_timeout, :heartbeat, :connect_timeout, :network_recovery_interval, :auto_delete_queue, :auto_delete_exchange
+    attr_reader :host, :hosts, :port, :user, :password, :application, :environment, :exchange, :pool_size, :pool_timeout, :heartbeat, :connect_timeout, :network_recovery_interval, :auto_delete_queue, :auto_delete_exchange
     validates_presence_of :application, :environment, :exchange, :pool_timeout
 
     def initialize options
       RabbitFeed.log.debug "RabbitFeed initialising with options: #{options}..."
 
       @host                      = options[:host]
+      @hosts                     = options[:hosts]
       @port                      = options[:port]
       @user                      = options[:user]
       @password                  = options[:password]
@@ -42,6 +43,7 @@ module RabbitFeed
         options[:heartbeat] = heartbeat if heartbeat
         options[:connect_timeout] = connect_timeout if connect_timeout
         options[:host] = host if host
+        options[:hosts] = hosts if hosts
         options[:user] = user if user
         options[:password] = password if password
         options[:port] = port if port

--- a/lib/rabbit_feed/version.rb
+++ b/lib/rabbit_feed/version.rb
@@ -1,3 +1,3 @@
 module RabbitFeed
-  VERSION = '2.1.2'
+  VERSION = '2.1.3'
 end

--- a/spec/lib/rabbit_feed/configuration_spec.rb
+++ b/spec/lib/rabbit_feed/configuration_spec.rb
@@ -119,6 +119,7 @@ module RabbitFeed
         end
 
         its(:host)                      { should be_nil }
+        its(:hosts)                     { should be_nil }
         its(:port)                      { should be_nil }
         its(:user)                      { should be_nil }
         its(:password)                  { should be_nil }
@@ -135,6 +136,7 @@ module RabbitFeed
         let(:options) do
           {
             host:                      'host_name',
+            hosts:                     ['host_name0', 'host_name1'],
             port:                      12345,
             user:                      'user_name',
             password:                  'password',
@@ -151,6 +153,7 @@ module RabbitFeed
         end
 
         its(:host)                      { should eq 'host_name' }
+        its(:hosts)                     { should eq ['host_name0', 'host_name1'] }
         its(:port)                      { should eq 12345 }
         its(:user)                      { should eq 'user_name' }
         its(:password)                  { should eq 'password' }


### PR DESCRIPTION
The purpose of this change is to allow us to forgo the load balancer and allow bunny to manage the hosts directly. This allows us to pass a list of hosts to bunny, of which it will choose one to connect and will failover upon lost connection.

@sparrovv @calo81 @daniel-barlow @PaulMcAdam @jaynefox @cpoo22 Could you please sign off?