### PR TITLE
Ensure clean exit of consumer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rabbit_feed (2.1.3)
+    rabbit_feed (2.1.4)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)
@@ -12,10 +12,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.1)
-      activesupport (= 4.2.1)
+    activemodel (4.2.3)
+      activesupport (= 4.2.3)
       builder (~> 3.1)
-    activesupport (4.2.1)
+    activesupport (4.2.3)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)

--- a/example/non_rails_app/Gemfile.lock
+++ b/example/non_rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.1.3)
+    rabbit_feed (2.1.4)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)
@@ -12,10 +12,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.1)
-      activesupport (= 4.2.1)
+    activemodel (4.2.3)
+      activesupport (= 4.2.3)
       builder (~> 3.1)
-    activesupport (4.2.1)
+    activesupport (4.2.3)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)

--- a/example/rails_app/Gemfile.lock
+++ b/example/rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.1.3)
+    rabbit_feed (2.1.4)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)

--- a/lib/rabbit_feed/consumer_connection.rb
+++ b/lib/rabbit_feed/consumer_connection.rb
@@ -42,9 +42,10 @@ module RabbitFeed
       end
 
       sleep # Sleep indefinitely, as the consumer runs in its own thread
-    rescue
+    rescue SystemExit, Interrupt
+      RabbitFeed.log.info "Consumer #{self.to_s} received exit request, exiting..."
+    ensure
       (cancel_consumer consumer) if consumer.present?
-      raise
     end
 
     private

--- a/lib/rabbit_feed/version.rb
+++ b/lib/rabbit_feed/version.rb
@@ -1,3 +1,3 @@
 module RabbitFeed
-  VERSION = '2.1.3'
+  VERSION = '2.1.4'
 end

--- a/spec/lib/rabbit_feed/consumer_connection_spec.rb
+++ b/spec/lib/rabbit_feed/consumer_connection_spec.rb
@@ -46,6 +46,7 @@ module RabbitFeed
       before do
         allow(bunny_queue).to receive(:subscribe).and_yield(double(:delivery_info, delivery_tag: :tag), 'properties', 'payload')
         allow_any_instance_of(described_class).to receive(:sleep)
+        allow_any_instance_of(described_class).to receive(:cancel_consumer)
       end
 
       it 'yields the payload' do
@@ -54,6 +55,11 @@ module RabbitFeed
 
       it 'acknowledges the message' do
         expect(bunny_channel).to receive(:ack)
+        subject.consume { }
+      end
+
+      it 'cancels the consumer' do
+        expect_any_instance_of(described_class).to receive(:cancel_consumer)
         subject.consume { }
       end
 


### PR DESCRIPTION
Previously, the interrupt exception would print an error on the console (see below) and prevent the consumer from cleaning up. This resolves both.

@sparrovv @calo81 Could you please sign off?

Exception printed to the console:

```
$ bundle exec rabbit_feed consume --environment development --require 'pooka/consumer'
^C/Users/jfleck/projects/pooka/vendor/bundle/ruby/2.0.0/gems/rabbit_feed-2.1.0/lib/rabbit_feed/consumer_connection.rb:44:in `sleep': Interrupt
	from /Users/jfleck/projects/pooka/vendor/bundle/ruby/2.0.0/gems/rabbit_feed-2.1.0/lib/rabbit_feed/consumer_connection.rb:44:in `consume'
	from /Users/jfleck/projects/pooka/vendor/bundle/ruby/2.0.0/gems/rabbit_feed-2.1.0/lib/rabbit_feed/consumer_connection.rb:33:in `block in consume'
	from /Users/jfleck/projects/pooka/vendor/bundle/ruby/2.0.0/gems/rabbit_feed-2.1.0/lib/rabbit_feed/connection_concern.rb:13:in `block in with_connection'
	from /Users/jfleck/projects/pooka/vendor/bundle/ruby/2.0.0/gems/connection_pool-2.1.2/lib/connection_pool.rb:62:in `with'
	from /Users/jfleck/projects/pooka/vendor/bundle/ruby/2.0.0/gems/rabbit_feed-2.1.0/lib/rabbit_feed/connection_concern.rb:12:in `with_connection'
	from /Users/jfleck/projects/pooka/vendor/bundle/ruby/2.0.0/gems/rabbit_feed-2.1.0/lib/rabbit_feed/consumer_connection.rb:32:in `consume'
	from /Users/jfleck/projects/pooka/vendor/bundle/ruby/2.0.0/gems/rabbit_feed-2.1.0/lib/rabbit_feed/consumer.rb:8:in `run'
	from /Users/jfleck/projects/pooka/vendor/bundle/ruby/2.0.0/gems/rabbit_feed-2.1.0/lib/rabbit_feed/client.rb:73:in `consume'
	from /Users/jfleck/projects/pooka/vendor/bundle/ruby/2.0.0/gems/rabbit_feed-2.1.0/lib/rabbit_feed/client.rb:40:in `run'
	from /Users/jfleck/projects/pooka/vendor/bundle/ruby/2.0.0/gems/rabbit_feed-2.1.0/bin/rabbit_feed:10:in `<top (required)>'
	from /Users/jfleck/projects/pooka/vendor/bundle/ruby/2.0.0/bin/rabbit_feed:23:in `load'
	from /Users/jfleck/projects/pooka/vendor/bundle/ruby/2.0.0/bin/rabbit_feed:23:in `<main>'
```