### PR TITLE
Make `application` a command line option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rabbit_feed (2.1.4)
+    rabbit_feed (2.1.5)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Publishes an event. Note: until you've specified the [event definitions](https:/
 Starts a consumer. Note: until you've specified the [event routing](https://github.com/simplybusiness/rabbit_feed#event-routing-dsl), this will not receive any events. Options are as follows:
 
     --environment The environment to run in
+    --application The name of the application (used for routing events)
     --config The location of the rabbit_feed configuration file
     --logfile The location of the log file
     --require The project file containing the dependancies (only necessary if running with non-rails application)

--- a/example/non_rails_app/Gemfile.lock
+++ b/example/non_rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.1.4)
+    rabbit_feed (2.1.5)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)

--- a/example/rails_app/Gemfile.lock
+++ b/example/rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.1.4)
+    rabbit_feed (2.1.5)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)

--- a/lib/rabbit_feed.rb
+++ b/lib/rabbit_feed.rb
@@ -26,13 +26,13 @@ module RabbitFeed
   class RoutingError < Error; end
   class ReturnedMessageError < Error; end
 
-  attr_accessor :log, :environment, :configuration_file_path
+  attr_accessor :log, :environment, :configuration_file_path, :application
 
   def configuration
     RabbitFeed.log                     ||= (Logger.new STDOUT)
     RabbitFeed.configuration_file_path ||= 'config/rabbit_feed.yml'
     RabbitFeed.environment             ||= ENV['RAILS_ENV'] || ENV['RACK_ENV']
-    @configuration                     ||= (Configuration.load RabbitFeed.configuration_file_path, RabbitFeed.environment)
+    @configuration                     ||= (Configuration.load RabbitFeed.configuration_file_path, RabbitFeed.environment, application)
   end
 
   def exception_notify exception

--- a/lib/rabbit_feed/client.rb
+++ b/lib/rabbit_feed/client.rb
@@ -92,6 +92,7 @@ module RabbitFeed
 
     def set_configuration
       RabbitFeed.environment             = environment
+      RabbitFeed.application             = options[:application]
       RabbitFeed.configuration_file_path = options[:config_file]
       ENV['RACK_ENV']  ||= RabbitFeed.environment
       ENV['RAILS_ENV'] ||= RabbitFeed.environment
@@ -137,6 +138,10 @@ module RabbitFeed
       opts = {}
 
       parser = OptionParser.new do |o|
+
+        o.on '-a', '--application VAL', 'Name of the application' do |arg|
+          opts[:application] = arg
+        end
 
         o.on '-m', '--payload VAL', 'Payload of event to produce' do |arg|
           opts[:payload] = arg

--- a/lib/rabbit_feed/configuration.rb
+++ b/lib/rabbit_feed/configuration.rb
@@ -25,13 +25,15 @@ module RabbitFeed
       validate!
     end
 
-    def self.load file_path, environment
-      RabbitFeed.log.debug "Reading configurations from #{file_path} in #{environment}..."
+    def self.load file_path, environment, application
+      RabbitFeed.log.debug "Reading configurations from #{file_path} in #{environment} for application #{application}..."
 
       raise ConfigurationError.new "The RabbitFeed configuration file path specified does not exist: #{file_path}" unless (File.exist? file_path)
 
       options = read_configuration_file file_path, environment
-      new options.merge(environment: environment)
+      options[:environment]   = environment
+      options[:application] ||= application
+      new options
     end
 
     def queue

--- a/lib/rabbit_feed/version.rb
+++ b/lib/rabbit_feed/version.rb
@@ -1,3 +1,3 @@
 module RabbitFeed
-  VERSION = '2.1.4'
+  VERSION = '2.1.5'
 end

--- a/spec/fixtures/configuration.yml
+++ b/spec/fixtures/configuration.yml
@@ -11,3 +11,4 @@ test:
   network_recovery_interval: 0.1
   auto_delete_queue: true
   auto_delete_exchange: true
+test_blank:

--- a/spec/lib/rabbit_feed/client_spec.rb
+++ b/spec/lib/rabbit_feed/client_spec.rb
@@ -8,6 +8,7 @@ module RabbitFeed
     let(:config_file) { 'spec/fixtures/configuration.yml' }
     let(:environment) { 'test' }
     let(:require_file){ 'rabbit_feed.rb' }
+    let(:application) { 'rabbit_feed_test' }
     let(:arguments) do
       [
         command,
@@ -21,11 +22,14 @@ module RabbitFeed
         pidfile,
         '--require',
         require_file,
+        '--application',
+        application,
         '--daemon'
       ]
     end
     before do
       RabbitFeed.environment = nil
+      RabbitFeed.application = nil
       RabbitFeed.log = nil
       RabbitFeed.configuration_file_path = nil
     end
@@ -38,6 +42,11 @@ module RabbitFeed
       it 'sets the environment' do
         subject
         expect(RabbitFeed.environment).to eq 'test'
+      end
+
+      it 'sets the application' do
+        subject
+        expect(RabbitFeed.application).to eq 'rabbit_feed_test'
       end
 
       it 'sets the logger' do

--- a/spec/lib/rabbit_feed/configuration_spec.rb
+++ b/spec/lib/rabbit_feed/configuration_spec.rb
@@ -69,7 +69,8 @@ module RabbitFeed
     describe '.load' do
       let(:file_path)   { 'spec/fixtures/configuration.yml' }
       let(:environment) { 'test' }
-      subject { described_class.load file_path, environment }
+      let(:application) { }
+      subject { described_class.load file_path, environment, application }
 
       context 'with missing configuration' do
         let(:environment) { 'production' }
@@ -104,6 +105,21 @@ module RabbitFeed
         its(:auto_delete_exchange)      { should be_truthy }
       end
 
+      context 'with application provided' do
+        let(:application) { 'new_application' }
+
+        it 'prefers the application specified in the config file' do
+          expect(subject.application).to eq 'rabbit_feed'
+        end
+
+        context 'with an empty config file' do
+          let(:environment) { 'test_blank' }
+
+          it 'prefers the application provided' do
+            expect(subject.application).to eq 'new_application'
+          end
+        end
+      end
     end
 
     describe '.new' do


### PR DESCRIPTION
The purpose of this change is to allow applications to share their `rabbit_feed.yml` file. The only application-specific attribute in the yml file is `application`, so removing this dependency fixes this. Am leaving `application` as an option in the yml for backwards compatibility. This change, in combination with  [this](https://github.com/simplybusiness/pooka/pull/133) change will enable us to remove the gnarly 2-app capistrano deploys [here](https://github.com/simplybusiness/puppetised-rabbit/blob/master/config/deploy/recipes/pooka.rb) and [here](https://github.com/simplybusiness/call_me_maybe/blob/master/config/deploy/recipes/pooka.rb).

@calo81 @sparrovv @ngsmrk Could you please sign off?