### PR TITLE
Bunny 2.0 official

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 PATH
   remote: .
   specs:
-    rabbit_feed (2.3.0)
+    rabbit_feed (2.3.1)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)
-      bunny (= 2.0.0.rc2)
+      bunny (>= 2.0.0, < 2.1.0)
       pidfile
 
 GEM
@@ -27,7 +27,7 @@ GEM
       debug_inspector (>= 0.0.1)
     bond (0.5.1)
     builder (3.2.2)
-    bunny (2.0.0.rc2)
+    bunny (2.0.0)
       amq-protocol (>= 1.9.2)
     codeclimate-test-reporter (0.4.6)
       simplecov (>= 0.7.1, < 1.0.0)

--- a/example/non_rails_app/Gemfile.lock
+++ b/example/non_rails_app/Gemfile.lock
@@ -1,11 +1,11 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.3.0)
+    rabbit_feed (2.3.1)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)
-      bunny (= 2.0.0.rc2)
+      bunny (>= 2.0.0, < 2.1.0)
       pidfile
 
 GEM
@@ -24,7 +24,7 @@ GEM
     avro (1.7.7)
       multi_json
     builder (3.2.2)
-    bunny (2.0.0.rc2)
+    bunny (2.0.0)
       amq-protocol (>= 1.9.2)
     diff-lcs (1.2.5)
     i18n (0.7.0)

--- a/example/rails_app/Gemfile.lock
+++ b/example/rails_app/Gemfile.lock
@@ -1,11 +1,11 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.3.0)
+    rabbit_feed (2.3.1)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)
-      bunny (= 2.0.0.rc2)
+      bunny (>= 2.0.0, < 2.1.0)
       pidfile
 
 GEM
@@ -51,7 +51,7 @@ GEM
     avro (1.7.7)
       multi_json
     builder (3.2.2)
-    bunny (2.0.0.rc2)
+    bunny (2.0.0)
       amq-protocol (>= 1.9.2)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)

--- a/lib/rabbit_feed/version.rb
+++ b/lib/rabbit_feed/version.rb
@@ -1,3 +1,3 @@
 module RabbitFeed
-  VERSION = '2.3.0'
+  VERSION = '2.3.1'
 end

--- a/rabbit_feed.gemspec
+++ b/rabbit_feed.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Gem for interfacing with RabbitMq
-  spec.add_dependency 'bunny', '2.0.0.rc2'
+  spec.add_dependency 'bunny', '>= 2.0.0', '< 2.1.0'
   # We use some helpers from ActiveSupport
   spec.add_dependency 'activesupport', '>= 3.2.0', '< 5.0.0'
   # We use validations from ActiveModel


### PR DESCRIPTION
Bunny 2.0 official has been released - allow RabbitFeed to use this version of Bunny.

@dawid-sklodowski @calo81 Could you please sign off?