### PR TITLE
Cucumber support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rabbit_feed (2.3.3)
+    rabbit_feed (2.3.4)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)
@@ -11,23 +11,23 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.3)
-      activesupport (= 4.2.3)
+    activemodel (4.2.4)
+      activesupport (= 4.2.4)
       builder (~> 3.1)
-    activesupport (4.2.3)
+    activesupport (4.2.4)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    amq-protocol (1.9.2)
+    amq-protocol (2.0.0)
     avro (1.7.7)
       multi_json
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     bond (0.5.1)
     builder (3.2.2)
-    bunny (2.0.0)
+    bunny (2.0.1)
       amq-protocol (>= 1.9.2)
     codeclimate-test-reporter (0.4.6)
       simplecov (>= 0.7.1, < 1.0.0)
@@ -50,7 +50,7 @@ GEM
       json
     json (1.8.2)
     method_source (0.8.2)
-    minitest (5.7.0)
+    minitest (5.8.3)
     multi_json (1.10.1)
     pidfile (0.3.0)
     pry (0.10.1)

--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ RSpec.configure do |config|
 end
 ```
 
+Or, if using Cucumber, put this in your `env.rb`:
+
+```ruby
+Before do
+  RabbitFeed::TestingSupport.capture_published_events_in_context(self)
+end
+```
+
 #### RSpec
 
 To verify that your application publishes an event, use the custom RSpec matcher provided with this application.

--- a/example/non_rails_app/Gemfile.lock
+++ b/example/non_rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.3.2)
+    rabbit_feed (2.3.3)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)
@@ -11,25 +11,25 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.3)
-      activesupport (= 4.2.3)
+    activemodel (4.2.4)
+      activesupport (= 4.2.4)
       builder (~> 3.1)
-    activesupport (4.2.3)
+    activesupport (4.2.4)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    amq-protocol (1.9.2)
+    amq-protocol (2.0.0)
     avro (1.7.7)
       multi_json
     builder (3.2.2)
-    bunny (2.0.0)
+    bunny (2.0.1)
       amq-protocol (>= 1.9.2)
     diff-lcs (1.2.5)
     i18n (0.7.0)
     json (1.8.3)
-    minitest (5.7.0)
+    minitest (5.8.3)
     multi_json (1.11.2)
     pidfile (0.3.0)
     rake (10.4.2)

--- a/example/non_rails_app/Gemfile.lock
+++ b/example/non_rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.3.3)
+    rabbit_feed (2.3.4)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)

--- a/example/rails_app/Gemfile.lock
+++ b/example/rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.3.3)
+    rabbit_feed (2.3.4)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)

--- a/example/rails_app/Gemfile.lock
+++ b/example/rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.3.2)
+    rabbit_feed (2.3.3)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)
@@ -46,12 +46,12 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    amq-protocol (1.9.2)
+    amq-protocol (2.0.0)
     arel (6.0.0)
     avro (1.7.7)
       multi_json
     builder (3.2.2)
-    bunny (2.0.0)
+    bunny (2.0.1)
       amq-protocol (>= 1.9.2)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)

--- a/lib/rabbit_feed/testing_support.rb
+++ b/lib/rabbit_feed/testing_support.rb
@@ -16,13 +16,16 @@ module RabbitFeed
 
     def capture_published_events rspec_config
       rspec_config.before :each do
+        TestingSupport.capture_published_events_in_context(self)
+      end
+    end
 
-        TestingSupport.published_events = []
-        mock_connection = double(:rabbitmq_connection)
-        allow(RabbitFeed::ProducerConnection).to receive(:instance).and_return(mock_connection)
-        allow(mock_connection).to receive(:publish) do |serialized_event, routing_key|
-          TestingSupport.published_events << (Event.deserialize serialized_event)
-        end
+    def capture_published_events_in_context context
+      TestingSupport.published_events = []
+      mock_connection = context.double(:rabbitmq_connection)
+      context.allow(RabbitFeed::ProducerConnection).to context.receive(:instance).and_return(mock_connection)
+      context.allow(mock_connection).to context.receive(:publish) do |serialized_event, routing_key|
+        TestingSupport.published_events << (Event.deserialize serialized_event)
       end
     end
 

--- a/lib/rabbit_feed/version.rb
+++ b/lib/rabbit_feed/version.rb
@@ -1,3 +1,3 @@
 module RabbitFeed
-  VERSION = '2.3.3'
+  VERSION = '2.3.4'
 end

--- a/run_example
+++ b/run_example
@@ -35,7 +35,7 @@ echo 'Rails application started'
 
 # Trigger an event
 echo 'Triggering event...'
-curl -silent -H -X POST http://localhost:8080/beavers -d "beaver[name]=`date '+%m/%d/%y %H:%M:%S'`" >/dev/null
+curl -silent --data "beaver[name]=`date '+%m/%d/%y %H:%M:%S'`" http://127.0.0.1:8080/beavers >/dev/null
 echo 'Event triggered'
 
 sleep 3


### PR DESCRIPTION
Extracting event publishing stubbing into its own method so that other testing libraries (e.g. Cucumber) can make use of the same stubbing as RSpec. 

Removes code duplication from: https://github.com/simplybusiness/continuous_cover/pull/861

@joseairosa @PeterWuMC Could you please sign off?