### PR TITLE
spec helper tasks a `Proc` as expected payload, so it can be evaluated later

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rabbit_feed (2.3.4)
+    rabbit_feed (2.3.5)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)
@@ -11,10 +11,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.4)
-      activesupport (= 4.2.4)
+    activemodel (4.2.5)
+      activesupport (= 4.2.5)
       builder (~> 3.1)
-    activesupport (4.2.4)
+    activesupport (4.2.5)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)

--- a/example/non_rails_app/Gemfile.lock
+++ b/example/non_rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.3.4)
+    rabbit_feed (2.3.5)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)
@@ -11,10 +11,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.4)
-      activesupport (= 4.2.4)
+    activemodel (4.2.5)
+      activesupport (= 4.2.5)
       builder (~> 3.1)
-    activesupport (4.2.4)
+    activesupport (4.2.5)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)

--- a/example/rails_app/Gemfile.lock
+++ b/example/rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.3.4)
+    rabbit_feed (2.3.5)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)
@@ -46,7 +46,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    amq-protocol (2.0.0)
+    amq-protocol (2.0.1)
     arel (6.0.0)
     avro (1.7.7)
       multi_json

--- a/lib/rabbit_feed/testing_support/rspec_matchers/publish_event.rb
+++ b/lib/rabbit_feed/testing_support/rspec_matchers/publish_event.rb
@@ -63,7 +63,7 @@ module RabbitFeed
           if !!@expected_payload
             ::Kernel.warn "`publish_event` was called with and expected payload already, anything in `with` is ignored"
           else
-            @expected_payload = expected_payload ? (->() { expected_payload }) : block
+            @expected_payload = expected_payload
           end
 
           self

--- a/lib/rabbit_feed/testing_support/rspec_matchers/publish_event.rb
+++ b/lib/rabbit_feed/testing_support/rspec_matchers/publish_event.rb
@@ -2,7 +2,7 @@ module RabbitFeed
   module TestingSupport
     module RSpecMatchers
       class PublishEvent
-        attr_reader :expected_event, :expected_payload
+        attr_reader :expected_event
 
         def initialize(expected_event, expected_payload)
           @expected_event   = expected_event
@@ -59,7 +59,21 @@ module RabbitFeed
           true
         end
 
+        def with(expected_payload=nil, &block)
+          if !!@expected_payload
+            ::Kernel.warn "`publish_event` was called with and expected payload already, anything in `with` is ignored"
+          else
+            @expected_payload = expected_payload ? (->() { expected_payload }) : block
+          end
+
+          self
+        end
+
         private
+
+        def expected_payload
+          @expected_payload.respond_to?(:call) ? @expected_payload.call : @expected_payload
+        end
 
         def received_events_message
           if TestingSupport.published_events.any?

--- a/lib/rabbit_feed/testing_support/rspec_matchers/publish_event.rb
+++ b/lib/rabbit_feed/testing_support/rspec_matchers/publish_event.rb
@@ -61,7 +61,7 @@ module RabbitFeed
 
         def with(expected_payload=nil, &block)
           if !!@expected_payload
-            ::Kernel.warn "`publish_event` was called with and expected payload already, anything in `with` is ignored"
+            ::Kernel.warn "`publish_event` was called with an expected payload already, anything in `with` is ignored"
           else
             @expected_payload = expected_payload
           end

--- a/lib/rabbit_feed/version.rb
+++ b/lib/rabbit_feed/version.rb
@@ -1,3 +1,3 @@
 module RabbitFeed
-  VERSION = '2.3.4'
+  VERSION = '2.3.5'
 end

--- a/spec/lib/rabbit_feed/testing_support/rspec_matchers/publish_event_spec.rb
+++ b/spec/lib/rabbit_feed/testing_support/rspec_matchers/publish_event_spec.rb
@@ -62,10 +62,22 @@ module RabbitFeed
           (matcher.matches? block).should be_falsey
         end
 
-        it 'validates the event payload' do
-          matcher = described_class.new(event_name, event_payload)
-          block   = Proc.new { RabbitFeed::Producer.publish_event event_name, {'field' => 'different value'} }
-          (matcher.matches? block).should be_falsey
+        context 'when validating the payload' do
+          context 'and the payload is not a Proc' do
+            it 'validates the event payload' do
+              matcher = described_class.new(event_name, event_payload)
+              block   = Proc.new { RabbitFeed::Producer.publish_event event_name, {'field' => 'different value'} }
+              (matcher.matches? block).should be_falsey
+            end
+          end
+
+          context 'and the payload is a Proc' do
+            it 'validates the event payload' do
+              matcher = described_class.new(event_name, event_payload)
+              block   = Proc.new { RabbitFeed::Producer.publish_event(event_name).with{{'field' => 'different value'}} }
+              (matcher.matches? block).should be_falsey
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
@joshuafleck @calo81 @daniel-barlow 

new rspec helper syntax
```ruby
expect { subject }.to publish_event('event_name', {'field' => 'different value'})
expect { subject }.to publish_event('event_name').with{ {'field' => 'different value'} }
expect { subject }.to publish_event('event_name').with({'field' => 'different value'})
```