### PR TITLE
Rabbit feed to support airbrake 5.0 above

### DIFF
--- a/example/non_rails_app/Gemfile.lock
+++ b/example/non_rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.3.8)
+    rabbit_feed (2.3.9)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)
@@ -11,10 +11,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.5.1)
-      activesupport (= 4.2.5.1)
+    activemodel (4.2.5)
+      activesupport (= 4.2.5)
       builder (~> 3.1)
-    activesupport (4.2.5.1)
+    activesupport (4.2.5)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -29,7 +29,7 @@ GEM
     diff-lcs (1.2.5)
     i18n (0.7.0)
     json (1.8.3)
-    minitest (5.8.4)
+    minitest (5.8.3)
     multi_json (1.11.2)
     pidfile (0.3.0)
     rake (10.4.2)

--- a/example/rails_app/Gemfile.lock
+++ b/example/rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.3.8)
+    rabbit_feed (2.3.9)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)

--- a/lib/rabbit_feed.rb
+++ b/lib/rabbit_feed.rb
@@ -34,7 +34,11 @@ module RabbitFeed
 
   def exception_notify exception
     if defined? Airbrake
-      (Airbrake.notify_or_ignore exception) if Airbrake.configuration.public?
+      if defined?(Airbrake::VERSION) && Airbrake::VERSION.to_i < 5
+        (Airbrake.notify_or_ignore exception) if Airbrake.configuration.public?
+      elsif defined?(Airbrake::AIRBRAKE_VERSION) && Airbrake::AIRBRAKE_VERSION.to_i >= 5
+        Airbrake.notify exception
+      end
     end
   end
 

--- a/lib/rabbit_feed/version.rb
+++ b/lib/rabbit_feed/version.rb
@@ -1,3 +1,3 @@
 module RabbitFeed
-  VERSION = '2.3.8'
+  VERSION = '2.3.9'
 end


### PR DESCRIPTION
@joshuafleck @calo81 

Airbrake 5.0 is completely different from 4.0 and is not backward compatible.