### PR TITLE
configuration.consumer_exit_after_fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,22 +38,23 @@ Sample:
 
 Configuration options that can be specified are:
 
-| Name | Use |
-| ---- | --- |
-| `host` | Hostname or IP of the RabbitMQ server |
-| `hosts` | Array of hostnames or IPs of a RabbitMQ cluster |
-| `port` | The port to use on the RabbitMQ server |
-| `user` | The user to authenticate with the RabbitMQ server |
-| `password` | The password to authenticate with the RabbitMQ server |
-| `application` | The name of the application - used for routing events to the specified consumers |
-| `environment` | The environment of the application - used for routing events to the specified consumers |
-| `exchange` | The name of the RabbitMQ exchange to which events are published |
-| `heartbeat` | The interval at which to send heartbeats to the RabbitMQ server (in seconds) |
-| `connect_timeout` | The timeout (in seconds) for connecting to the RabbitMQ server |
-| `network_recovery_interval` | Recovery interval (in seconds) periodic network recovery will use |
-| `auto_delete_queue` | If true, any queues created will auto-delete upon disconnect |
-| `auto_delete_exchange` | If true, any exchanges created will auto-delete upon disconnect |
-| `route_prefix_extension` | If set, the routing key/queue of the exchange will become env.`route_prefix_extension`.application.event |
+| Name                        | Use                                                                                                                                       |
+| ----                        | ---                                                                                                                                       |
+| `host`                      | Hostname or IP of the RabbitMQ server                                                                                                     |
+| `hosts`                     | Array of hostnames or IPs of a RabbitMQ cluster                                                                                           |
+| `port`                      | The port to use on the RabbitMQ server                                                                                                    |
+| `user`                      | The user to authenticate with the RabbitMQ server                                                                                         |
+| `password`                  | The password to authenticate with the RabbitMQ server                                                                                     |
+| `application`               | The name of the application - used for routing events to the specified consumers                                                          |
+| `environment`               | The environment of the application - used for routing events to the specified consumers                                                   |
+| `exchange`                  | The name of the RabbitMQ exchange to which events are published                                                                           |
+| `heartbeat`                 | The interval at which to send heartbeats to the RabbitMQ server (in seconds)                                                              |
+| `connect_timeout`           | The timeout (in seconds) for connecting to the RabbitMQ server                                                                            |
+| `network_recovery_interval` | Recovery interval (in seconds) periodic network recovery will use                                                                         |
+| `auto_delete_queue`         | If true, any queues created will auto-delete upon disconnect                                                                              |
+| `auto_delete_exchange`      | If true, any exchanges created will auto-delete upon disconnect                                                                           |
+| `route_prefix_extension`    | If set, the routing key/queue of the exchange will become env.`route_prefix_extension`.application.event                                  |
+| `consumer_exit_after_fail`  | If set, consumer will stop consuming as soon as it fail to process an event. By Default, it will continue to consume and log the error(s) |
 
 ### Initialisation
 

--- a/lib/rabbit_feed/configuration.rb
+++ b/lib/rabbit_feed/configuration.rb
@@ -3,7 +3,8 @@ module RabbitFeed
     include ActiveModel::Validations
 
     attr_reader :host, :hosts, :port, :user, :password, :application, :environment, :exchange, :heartbeat,
-                :connect_timeout, :network_recovery_interval, :auto_delete_queue, :auto_delete_exchange
+                :connect_timeout, :network_recovery_interval, :auto_delete_queue, :auto_delete_exchange,
+                :consumer_exit_after_fail
     validates_presence_of :application, :environment, :exchange
 
     def initialize options
@@ -23,6 +24,7 @@ module RabbitFeed
       @application               = options[:application]
       @environment               = options[:environment]
       @route_prefix_extension    = options[:route_prefix_extension]
+      @consumer_exit_after_fail  = options[:consumer_exit_after_fail] || false
       validate!
     end
 

--- a/lib/rabbit_feed/consumer_connection.rb
+++ b/lib/rabbit_feed/consumer_connection.rb
@@ -79,6 +79,7 @@ module RabbitFeed
         acknowledge delivery_info
       rescue => e
         handle_processing_exception delivery_info, e
+        raise if RabbitFeed.configuration.consumer_exit_after_fail
       end
     end
 

--- a/spec/lib/rabbit_feed/configuration_spec.rb
+++ b/spec/lib/rabbit_feed/configuration_spec.rb
@@ -154,6 +154,7 @@ module RabbitFeed
         its(:connect_timeout)           { should be_nil }
         its(:auto_delete_queue)         { should be_falsey }
         its(:auto_delete_exchange)      { should be_falsey }
+        its(:consumer_exit_after_fail)  { should be_falsey }
       end
 
       context 'with provided options' do
@@ -172,6 +173,7 @@ module RabbitFeed
             network_recovery_interval: 2,
             auto_delete_queue:         'true',
             auto_delete_exchange:      'false',
+            consumer_exit_after_fail:  'true'
           }
         end
 
@@ -188,6 +190,7 @@ module RabbitFeed
         its(:network_recovery_interval) { should eq 2 }
         its(:auto_delete_queue)         { should be_truthy }
         its(:auto_delete_exchange)      { should be_truthy }
+        its(:consumer_exit_after_fail)  { should be_truthy }
       end
 
       context 'with empty options' do

--- a/spec/lib/rabbit_feed/consumer_connection_spec.rb
+++ b/spec/lib/rabbit_feed/consumer_connection_spec.rb
@@ -79,46 +79,60 @@ module RabbitFeed
 
       context 'when an exception is raised' do
 
-        context 'when Airbrake is defined' do
-          after { Object.send(:remove_const, ('Airbrake').to_sym) rescue NameError }
+        context 'when consumer_exit_after_fail is true' do
+          before { allow(RabbitFeed.configuration).to receive(:consumer_exit_after_fail).and_return(true) }
 
-          context 'when the version is lower than 5' do
-            before do
-              module ::Airbrake
-                VERSION = '4.0.0'
+          it 'raises the exception' do
+            expect{ subject.consume { raise 'Consuming time' } }.to raise_error('Consuming time')
+          end
+        end
+
+
+        context 'when consumer_exit_after_fail is false' do
+          before { allow(RabbitFeed.configuration).to receive(:consumer_exit_after_fail).and_return(false) }
+
+          context 'when Airbrake is defined' do
+            after { Object.send(:remove_const, ('Airbrake').to_sym) rescue NameError }
+
+            context 'when the version is lower than 5' do
+              before do
+                module ::Airbrake
+                  VERSION = '4.0.0'
+                end
+                allow(Airbrake).to receive(:configuration).and_return(airbrake_configuration)
               end
-              allow(Airbrake).to receive(:configuration).and_return(airbrake_configuration)
+
+              context 'and the Airbrake configuration is public' do
+                let(:airbrake_configuration) { double(:airbrake_configuration, public?: true) }
+
+                it 'notifies airbrake' do
+                  expect(Airbrake).to receive(:notify_or_ignore).with(an_instance_of RuntimeError)
+
+                  expect{ subject.consume { raise 'Consuming time' } }.not_to raise_error
+                end
+              end
             end
 
-            context 'and the Airbrake configuration is public' do
-              let(:airbrake_configuration) { double(:airbrake_configuration, public?: true) }
+            context 'when the version is greater than 4' do
+              before do
+                module ::Airbrake
+                  AIRBRAKE_VERSION = '5.0.0'
+                end
+              end
 
               it 'notifies airbrake' do
-                expect(Airbrake).to receive(:notify_or_ignore).with(an_instance_of RuntimeError)
-
+                expect(Airbrake).to receive(:notify).with(an_instance_of RuntimeError)
                 expect{ subject.consume { raise 'Consuming time' } }.not_to raise_error
               end
             end
           end
 
-          context 'when the version is greater than 4' do
-            before do
-              module ::Airbrake
-                AIRBRAKE_VERSION = '5.0.0'
-              end
-            end
-
-            it 'notifies airbrake' do
-              expect(Airbrake).to receive(:notify).with(an_instance_of RuntimeError)
-              expect{ subject.consume { raise 'Consuming time' } }.not_to raise_error
-            end
+          it 'negatively acknowledges the message' do
+            expect(bunny_channel).to receive(:nack)
+            subject.consume { raise 'Consuming time' }
           end
         end
 
-        it 'negatively acknowledges the message' do
-          expect(bunny_channel).to receive(:nack)
-          subject.consume { raise 'Consuming time' }
-        end
       end
     end
   end


### PR DESCRIPTION
@joshuafleck @calo81 

Added a new option to stop the consumer from consuming as soon as any error occur.