### PR TITLE
Consumer exit after fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,22 +38,23 @@ Sample:
 
 Configuration options that can be specified are:
 
-| Name | Use |
-| ---- | --- |
-| `host` | Hostname or IP of the RabbitMQ server |
-| `hosts` | Array of hostnames or IPs of a RabbitMQ cluster |
-| `port` | The port to use on the RabbitMQ server |
-| `user` | The user to authenticate with the RabbitMQ server |
-| `password` | The password to authenticate with the RabbitMQ server |
-| `application` | The name of the application - used for routing events to the specified consumers |
-| `environment` | The environment of the application - used for routing events to the specified consumers |
-| `exchange` | The name of the RabbitMQ exchange to which events are published |
-| `heartbeat` | The interval at which to send heartbeats to the RabbitMQ server (in seconds) |
-| `connect_timeout` | The timeout (in seconds) for connecting to the RabbitMQ server |
-| `network_recovery_interval` | Recovery interval (in seconds) periodic network recovery will use |
-| `auto_delete_queue` | If true, any queues created will auto-delete upon disconnect |
-| `auto_delete_exchange` | If true, any exchanges created will auto-delete upon disconnect |
-| `route_prefix_extension` | If set, the routing key/queue of the exchange will become env.`route_prefix_extension`.application.event |
+| Name                        | Use                                                                                                                                       |
+| ----                        | ---                                                                                                                                       |
+| `host`                      | Hostname or IP of the RabbitMQ server                                                                                                     |
+| `hosts`                     | Array of hostnames or IPs of a RabbitMQ cluster                                                                                           |
+| `port`                      | The port to use on the RabbitMQ server                                                                                                    |
+| `user`                      | The user to authenticate with the RabbitMQ server                                                                                         |
+| `password`                  | The password to authenticate with the RabbitMQ server                                                                                     |
+| `application`               | The name of the application - used for routing events to the specified consumers                                                          |
+| `environment`               | The environment of the application - used for routing events to the specified consumers                                                   |
+| `exchange`                  | The name of the RabbitMQ exchange to which events are published                                                                           |
+| `heartbeat`                 | The interval at which to send heartbeats to the RabbitMQ server (in seconds)                                                              |
+| `connect_timeout`           | The timeout (in seconds) for connecting to the RabbitMQ server                                                                            |
+| `network_recovery_interval` | Recovery interval (in seconds) periodic network recovery will use                                                                         |
+| `auto_delete_queue`         | If true, any queues created will auto-delete upon disconnect                                                                              |
+| `auto_delete_exchange`      | If true, any exchanges created will auto-delete upon disconnect                                                                           |
+| `route_prefix_extension`    | If set, the routing key/queue of the exchange will become env.`route_prefix_extension`.application.event                                  |
+| `consumer_exit_after_fail`  | If set, consumer will stop consuming as soon as it fail to process an event. By Default, it will continue to consume and log the error(s) |
 
 ### Initialisation
 

--- a/README.md
+++ b/README.md
@@ -38,23 +38,23 @@ Sample:
 
 Configuration options that can be specified are:
 
-| Name                        | Use                                                                                                                                       |
-| ----                        | ---                                                                                                                                       |
-| `host`                      | Hostname or IP of the RabbitMQ server                                                                                                     |
-| `hosts`                     | Array of hostnames or IPs of a RabbitMQ cluster                                                                                           |
-| `port`                      | The port to use on the RabbitMQ server                                                                                                    |
-| `user`                      | The user to authenticate with the RabbitMQ server                                                                                         |
-| `password`                  | The password to authenticate with the RabbitMQ server                                                                                     |
-| `application`               | The name of the application - used for routing events to the specified consumers                                                          |
-| `environment`               | The environment of the application - used for routing events to the specified consumers                                                   |
-| `exchange`                  | The name of the RabbitMQ exchange to which events are published                                                                           |
-| `heartbeat`                 | The interval at which to send heartbeats to the RabbitMQ server (in seconds)                                                              |
-| `connect_timeout`           | The timeout (in seconds) for connecting to the RabbitMQ server                                                                            |
-| `network_recovery_interval` | Recovery interval (in seconds) periodic network recovery will use                                                                         |
-| `auto_delete_queue`         | If true, any queues created will auto-delete upon disconnect                                                                              |
-| `auto_delete_exchange`      | If true, any exchanges created will auto-delete upon disconnect                                                                           |
-| `route_prefix_extension`    | If set, the routing key/queue of the exchange will become env.`route_prefix_extension`.application.event                                  |
-| `consumer_exit_after_fail`  | If set, consumer will stop consuming as soon as it fail to process an event. By Default, it will continue to consume and log the error(s) |
+| Name                        | Use                                                                                                                                        |
+| ----                        | ---                                                                                                                                        |
+| `host`                      | Hostname or IP of the RabbitMQ server                                                                                                      |
+| `hosts`                     | Array of hostnames or IPs of a RabbitMQ cluster                                                                                            |
+| `port`                      | The port to use on the RabbitMQ server                                                                                                     |
+| `user`                      | The user to authenticate with the RabbitMQ server                                                                                          |
+| `password`                  | The password to authenticate with the RabbitMQ server                                                                                      |
+| `application`               | The name of the application - used for routing events to the specified consumers                                                           |
+| `environment`               | The environment of the application - used for routing events to the specified consumers                                                    |
+| `exchange`                  | The name of the RabbitMQ exchange to which events are published                                                                            |
+| `heartbeat`                 | The interval at which to send heartbeats to the RabbitMQ server (in seconds)                                                               |
+| `connect_timeout`           | The timeout (in seconds) for connecting to the RabbitMQ server                                                                             |
+| `network_recovery_interval` | Recovery interval (in seconds) periodic network recovery will use                                                                          |
+| `auto_delete_queue`         | If true, any queues created will auto-delete upon disconnect                                                                               |
+| `auto_delete_exchange`      | If true, any exchanges created will auto-delete upon disconnect                                                                            |
+| `route_prefix_extension`    | If set, the routing key/queue of the exchange will become env.`route_prefix_extension`.application.event                                   |
+| `consumer_exit_after_fail`  | If set, consumer will stop consuming as soon as it fails to process an event. By default, it will continue to consume and log the error(s) |
 
 ### Initialisation
 

--- a/example/non_rails_app/Gemfile.lock
+++ b/example/non_rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.3.9)
+    rabbit_feed (2.3.10)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)
@@ -11,10 +11,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.5)
-      activesupport (= 4.2.5)
+    activemodel (4.2.5.1)
+      activesupport (= 4.2.5.1)
       builder (~> 3.1)
-    activesupport (4.2.5)
+    activesupport (4.2.5.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -29,7 +29,7 @@ GEM
     diff-lcs (1.2.5)
     i18n (0.7.0)
     json (1.8.3)
-    minitest (5.8.3)
+    minitest (5.8.4)
     multi_json (1.11.2)
     pidfile (0.3.0)
     rake (10.4.2)

--- a/example/rails_app/Gemfile.lock
+++ b/example/rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.3.9)
+    rabbit_feed (2.3.10)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)

--- a/lib/rabbit_feed/configuration.rb
+++ b/lib/rabbit_feed/configuration.rb
@@ -3,7 +3,8 @@ module RabbitFeed
     include ActiveModel::Validations
 
     attr_reader :host, :hosts, :port, :user, :password, :application, :environment, :exchange, :heartbeat,
-                :connect_timeout, :network_recovery_interval, :auto_delete_queue, :auto_delete_exchange
+                :connect_timeout, :network_recovery_interval, :auto_delete_queue, :auto_delete_exchange,
+                :consumer_exit_after_fail
     validates_presence_of :application, :environment, :exchange
 
     def initialize options
@@ -23,6 +24,7 @@ module RabbitFeed
       @application               = options[:application]
       @environment               = options[:environment]
       @route_prefix_extension    = options[:route_prefix_extension]
+      @consumer_exit_after_fail  = options[:consumer_exit_after_fail] || false
       validate!
     end
 

--- a/lib/rabbit_feed/consumer_connection.rb
+++ b/lib/rabbit_feed/consumer_connection.rb
@@ -79,6 +79,7 @@ module RabbitFeed
         acknowledge delivery_info
       rescue => e
         handle_processing_exception delivery_info, e
+        raise if RabbitFeed.configuration.consumer_exit_after_fail
       end
     end
 

--- a/lib/rabbit_feed/consumer_connection.rb
+++ b/lib/rabbit_feed/consumer_connection.rb
@@ -79,7 +79,7 @@ module RabbitFeed
         acknowledge delivery_info
       rescue => e
         handle_processing_exception delivery_info, e
-        raise if RabbitFeed.configuration.consumer_exit_after_fail
+        exit(1) if RabbitFeed.configuration.consumer_exit_after_fail
       end
     end
 

--- a/lib/rabbit_feed/version.rb
+++ b/lib/rabbit_feed/version.rb
@@ -1,3 +1,3 @@
 module RabbitFeed
-  VERSION = '2.3.9'
+  VERSION = '2.3.10'
 end

--- a/spec/lib/rabbit_feed/configuration_spec.rb
+++ b/spec/lib/rabbit_feed/configuration_spec.rb
@@ -154,6 +154,7 @@ module RabbitFeed
         its(:connect_timeout)           { should be_nil }
         its(:auto_delete_queue)         { should be_falsey }
         its(:auto_delete_exchange)      { should be_falsey }
+        its(:consumer_exit_after_fail)  { should be_falsey }
       end
 
       context 'with provided options' do
@@ -172,6 +173,7 @@ module RabbitFeed
             network_recovery_interval: 2,
             auto_delete_queue:         'true',
             auto_delete_exchange:      'false',
+            consumer_exit_after_fail:  'true'
           }
         end
 
@@ -188,6 +190,7 @@ module RabbitFeed
         its(:network_recovery_interval) { should eq 2 }
         its(:auto_delete_queue)         { should be_truthy }
         its(:auto_delete_exchange)      { should be_truthy }
+        its(:consumer_exit_after_fail)  { should be_truthy }
       end
 
       context 'with empty options' do

--- a/spec/lib/rabbit_feed/consumer_connection_spec.rb
+++ b/spec/lib/rabbit_feed/consumer_connection_spec.rb
@@ -82,7 +82,7 @@ module RabbitFeed
         context 'when consumer_exit_after_fail is true' do
           before { allow(RabbitFeed.configuration).to receive(:consumer_exit_after_fail).and_return(true) }
 
-          it 'raises the exception' do
+          it 'exits the application' do
             expect_any_instance_of(described_class).to receive(:exit).with(1)
             subject.consume { raise 'Consuming time' }
           end

--- a/spec/lib/rabbit_feed/consumer_connection_spec.rb
+++ b/spec/lib/rabbit_feed/consumer_connection_spec.rb
@@ -83,7 +83,8 @@ module RabbitFeed
           before { allow(RabbitFeed.configuration).to receive(:consumer_exit_after_fail).and_return(true) }
 
           it 'raises the exception' do
-            expect{ subject.consume { raise 'Consuming time' } }.to raise_error('Consuming time')
+            expect_any_instance_of(described_class).to receive(:exit).with(1)
+            subject.consume { raise 'Consuming time' }
           end
         end
 

--- a/spec/lib/rabbit_feed/consumer_connection_spec.rb
+++ b/spec/lib/rabbit_feed/consumer_connection_spec.rb
@@ -79,46 +79,60 @@ module RabbitFeed
 
       context 'when an exception is raised' do
 
-        context 'when Airbrake is defined' do
-          after { Object.send(:remove_const, ('Airbrake').to_sym) rescue NameError }
+        context 'when consumer_exit_after_fail is true' do
+          before { allow(RabbitFeed.configuration).to receive(:consumer_exit_after_fail).and_return(true) }
 
-          context 'when the version is lower than 5' do
-            before do
-              module ::Airbrake
-                VERSION = '4.0.0'
+          it 'raises the exception' do
+            expect{ subject.consume { raise 'Consuming time' } }.to raise_error('Consuming time')
+          end
+        end
+
+
+        context 'when consumer_exit_after_fail is false' do
+          before { allow(RabbitFeed.configuration).to receive(:consumer_exit_after_fail).and_return(false) }
+
+          context 'when Airbrake is defined' do
+            after { Object.send(:remove_const, ('Airbrake').to_sym) rescue NameError }
+
+            context 'when the version is lower than 5' do
+              before do
+                module ::Airbrake
+                  VERSION = '4.0.0'
+                end
+                allow(Airbrake).to receive(:configuration).and_return(airbrake_configuration)
               end
-              allow(Airbrake).to receive(:configuration).and_return(airbrake_configuration)
+
+              context 'and the Airbrake configuration is public' do
+                let(:airbrake_configuration) { double(:airbrake_configuration, public?: true) }
+
+                it 'notifies airbrake' do
+                  expect(Airbrake).to receive(:notify_or_ignore).with(an_instance_of RuntimeError)
+
+                  expect{ subject.consume { raise 'Consuming time' } }.not_to raise_error
+                end
+              end
             end
 
-            context 'and the Airbrake configuration is public' do
-              let(:airbrake_configuration) { double(:airbrake_configuration, public?: true) }
+            context 'when the version is greater than 4' do
+              before do
+                module ::Airbrake
+                  AIRBRAKE_VERSION = '5.0.0'
+                end
+              end
 
               it 'notifies airbrake' do
-                expect(Airbrake).to receive(:notify_or_ignore).with(an_instance_of RuntimeError)
-
+                expect(Airbrake).to receive(:notify).with(an_instance_of RuntimeError)
                 expect{ subject.consume { raise 'Consuming time' } }.not_to raise_error
               end
             end
           end
 
-          context 'when the version is greater than 4' do
-            before do
-              module ::Airbrake
-                AIRBRAKE_VERSION = '5.0.0'
-              end
-            end
-
-            it 'notifies airbrake' do
-              expect(Airbrake).to receive(:notify).with(an_instance_of RuntimeError)
-              expect{ subject.consume { raise 'Consuming time' } }.not_to raise_error
-            end
+          it 'negatively acknowledges the message' do
+            expect(bunny_channel).to receive(:nack)
+            subject.consume { raise 'Consuming time' }
           end
         end
 
-        it 'negatively acknowledges the message' do
-          expect(bunny_channel).to receive(:nack)
-          subject.consume { raise 'Consuming time' }
-        end
       end
     end
   end


### PR DESCRIPTION
@joshuafleck @calo81 

second time lucky!!

so this time i decide to do `exit(1)`, simply re-raising the exception does not help. because bunny rescues any exceptions: https://github.com/ruby-amqp/bunny/blob/master/lib/bunny/consumer_work_pool.rb#L87-L102