### PR TITLE
Console consumer tool [WIP]

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,9 +272,35 @@ _This only applies if you've started the consumer with the `--daemon` option._
 
 ### Console Consumer
 
-    bundle exec bin/rabbit_feed console --environment test --config spec/fixtures/configuration.yml --logfile test.log --pidfile rabbit_feed.pid --verbose
+    bundle exec bin/rabbit_feed console --environment development --config spec/fixtures/configuration.yml --logfile development.log --pidfile rabbit_feed.pid --verbose
 
 The console consumer will accept any event from any application and will print the event metadata and payload to the console. This is useful during development to get instant feedback on the events being published.
+
+#### Example Console Output
+
+```
+RabbitFeed console starting at 2016-02-08 16:22:22 UTC...
+Environment: development
+Queue: development.rabbit_feed_console
+There are currently 4 message(s) in the console's queue.
+Would you like to purge the queue before proceeding? (y/N)>
+n
+Ready. Press CTRL+C to exit.
+----------------------------user_creates_beaver: 2016-02-08 16:19:30 UTC----------------------------
+#Event metadata
+application: rails_app
+created_at_utc: 2016-02-08T16:19:30.530210Z
+environment: development
+host: localhost
+name: user_creates_beaver
+schema_version: 2.0.0
+version: 1.0.0
+****************************************************************************************************
+#Event payload
+beaver_name: 02/08/16 16:19:30
+----------------------------------------------------------------------------------------------------
+1 events received.
+```
 
 ## Event Definitions DSL
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,12 @@ Starts a consumer. Note: until you've specified the [event routing](https://gith
 
 _This only applies if you've started the consumer with the `--daemon` option._
 
+### Console Consumer
+
+    bundle exec bin/rabbit_feed console --environment test --config spec/fixtures/configuration.yml --logfile test.log --pidfile rabbit_feed.pid --verbose
+
+The console consumer will accept any event from any application and will print the event metadata and payload to the console. This is useful during development to get instant feedback on the events being published.
+
 ## Event Definitions DSL
 
 Provides a means to define all events that are published by an application. Defines the event names and the payload associated with each event. The DSL is converted into a schema that is serialized along with the event payload, meaning the events are self-describing. This is accomplished using Apache [Avro](http://avro.apache.org/docs/current/). This also validates the event payload against its schema before it is published.

--- a/Rakefile
+++ b/Rakefile
@@ -6,12 +6,12 @@ task :default => [:all]
 
 desc 'Run specs and features'
 RSpec::Core::RakeTask.new(:all) do |t|
-  t.pattern = './spec/{**/*_spec.rb,features/**/*.feature}'
+  t.pattern = "spec/{**/*_spec.rb,features/**/*.feature}"
 end
 
 desc 'Run specs'
 RSpec::Core::RakeTask.new(:spec) do |t|
-  t.pattern = './spec/{**/*_spec.rb}'
+  t.pattern = "spec/**/*_spec.rb"
 end
 
 def gemspec

--- a/example/non_rails_app/Gemfile.lock
+++ b/example/non_rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.3.10)
+    rabbit_feed (2.4.0)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)
@@ -59,4 +59,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/example/rails_app/Gemfile.lock
+++ b/example/rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.3.10)
+    rabbit_feed (2.4.0)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)
@@ -189,4 +189,4 @@ DEPENDENCIES
   unicorn
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/lib/rabbit_feed/client.rb
+++ b/lib/rabbit_feed/client.rb
@@ -16,10 +16,10 @@ module RabbitFeed
 
     attr_reader :command, :options
     validates_presence_of :command, :options
-    validates :command, inclusion: { in: %w(consume produce shutdown), message: "%{value} is not a valid command" }
+    validates :command, inclusion: { in: %w(consume produce shutdown console), message: "%{value} is not a valid command" }
     validate :log_file_path_exists
     validate :config_file_exists
-    validate :require_path_valid
+    validate :require_path_valid, unless: :console?
     validate :pidfile_path_exists, if: :daemonize?
     validate :environment_specified
 
@@ -32,7 +32,7 @@ module RabbitFeed
 
         set_logging
         set_configuration
-        load_dependancies
+        load_dependancies unless console?
       end
     end
 
@@ -70,6 +70,12 @@ module RabbitFeed
 
     def consume
       daemonize if daemonize?
+      RabbitFeed::Consumer.run
+    end
+
+    def console
+      require_relative 'console_consumer'
+      ConsoleConsumer.init
       RabbitFeed::Consumer.run
     end
 
@@ -125,6 +131,10 @@ module RabbitFeed
 
     def daemonize?
       options[:daemon]
+    end
+
+    def console?
+      command == 'console'
     end
 
     def verbose?

--- a/lib/rabbit_feed/client.rb
+++ b/lib/rabbit_feed/client.rb
@@ -76,7 +76,7 @@ module RabbitFeed
     def console
       require_relative 'console_consumer'
       ConsoleConsumer.init
-      RabbitFeed::Consumer.run
+      consume
     end
 
     def shutdown

--- a/lib/rabbit_feed/console_consumer.rb
+++ b/lib/rabbit_feed/console_consumer.rb
@@ -1,0 +1,97 @@
+module RabbitFeed
+  module ConsoleConsumer
+    extend self
+
+    def init
+      route_all_events
+      puts welcome_message
+      ask_to_purge_queue unless ConsumerConnection.instance.queue_depth.zero?
+      puts "Ready. Press CTRL+C to exit."
+    end
+
+    def print_to_console event
+      puts Formatter.new(event).to_s
+    end
+
+    private
+
+    def welcome_message
+"""RabbitFeed console starting at #{Time.now.utc}...
+Environment: #{RabbitFeed.environment}
+Queue: #{RabbitFeed.configuration.queue}
+"""
+    end
+
+    def ask_to_purge_queue
+      puts "There are currently #{ConsumerConnection.instance.queue_depth} message(s) in the console's queue.\n"+
+      "Would you like to purge the queue before proceeding? (y/N)>"
+      response = STDIN.gets.chomp
+      purge_queue if response == 'y'
+    end
+
+    def purge_queue
+      ConsumerConnection.instance.purge_queue
+      puts "Queue purged."
+    end
+
+    def route_all_events
+      scope = self
+      EventRouting do
+        accept_from(:any) do
+          event(:any) do |event|
+            scope.print_to_console event
+          end
+        end
+      end
+    end
+
+    class Formatter
+
+      BORDER_WIDTH = 100
+      BORDER_CHAR  = "-"
+      DIVIDER_CHAR = "*"
+      NEWLINE      = "\n"
+
+      attr_reader :event
+
+      def initialize event
+        @event = event
+      end
+
+      def to_s
+        [header, metadata, divider, payload, footer].join(NEWLINE)
+      end
+
+      private
+
+      def header
+        event_detail = "#{event.name}: #{event.created_at_utc}"
+        border_filler = BORDER_CHAR*((BORDER_WIDTH - event_detail.length)/2)
+        border_filler+event_detail+border_filler
+      end
+
+      def footer
+        BORDER_CHAR*BORDER_WIDTH
+      end
+
+      def metadata
+        pretty_print_hash 'Event metadata', event.metadata
+      end
+
+      def divider
+        DIVIDER_CHAR*BORDER_WIDTH
+      end
+
+      def payload
+        pretty_print_hash 'Event payload', event.payload
+      end
+
+      def pretty_print_hash description, hash
+        '#' + description + NEWLINE +
+        hash.keys.sort.map do |key|
+          "#{key}: #{hash[key]}"
+        end.join(NEWLINE)
+      end
+    end
+  end
+end

--- a/lib/rabbit_feed/console_consumer.rb
+++ b/lib/rabbit_feed/console_consumer.rb
@@ -5,6 +5,7 @@ module RabbitFeed
     APPLICATION_NAME = 'rabbit_feed_console'
 
     def init
+      @event_count = 0
       set_application
       route_all_events
       puts welcome_message
@@ -12,8 +13,16 @@ module RabbitFeed
       puts "Ready. Press CTRL+C to exit."
     end
 
-    def print_to_console event
-      puts Formatter.new(event).to_s
+    def formatted event
+      Formatter.new(event).to_s
+    end
+
+    def event_count_message
+      "#{@event_count} events received."
+    end
+
+    def increment_event_count
+      @event_count += 1
     end
 
     private
@@ -42,7 +51,9 @@ Queue: #{RabbitFeed.configuration.queue}
       EventRouting do
         accept_from(:any) do
           event(:any) do |event|
-            scope.print_to_console event
+            scope.increment_event_count
+            puts (scope.formatted event)
+            puts scope.event_count_message
           end
         end
       end

--- a/lib/rabbit_feed/console_consumer.rb
+++ b/lib/rabbit_feed/console_consumer.rb
@@ -9,7 +9,7 @@ module RabbitFeed
       set_application
       route_all_events
       puts welcome_message
-      ask_to_purge_queue unless ConsumerConnection.instance.queue_depth.zero?
+      ask_to_purge_queue unless queue_empty?
       puts "Ready. Press CTRL+C to exit."
     end
 
@@ -32,6 +32,10 @@ module RabbitFeed
 Environment: #{RabbitFeed.environment}
 Queue: #{RabbitFeed.configuration.queue}
 """
+    end
+
+    def queue_empty?
+      ConsumerConnection.instance.queue_depth.zero?
     end
 
     def ask_to_purge_queue

--- a/lib/rabbit_feed/console_consumer.rb
+++ b/lib/rabbit_feed/console_consumer.rb
@@ -2,7 +2,10 @@ module RabbitFeed
   module ConsoleConsumer
     extend self
 
+    APPLICATION_NAME = 'rabbit_feed_console'
+
     def init
+      set_application
       route_all_events
       puts welcome_message
       ask_to_purge_queue unless ConsumerConnection.instance.queue_depth.zero?
@@ -43,6 +46,10 @@ Queue: #{RabbitFeed.configuration.queue}
           end
         end
       end
+    end
+
+    def set_application
+      RabbitFeed.application = APPLICATION_NAME
     end
 
     class Formatter

--- a/lib/rabbit_feed/consumer_connection.rb
+++ b/lib/rabbit_feed/consumer_connection.rb
@@ -45,6 +45,14 @@ module RabbitFeed
       end
     end
 
+    def queue_depth
+      @queue.message_count
+    end
+
+    def purge_queue
+      @queue.purge
+    end
+
     private
 
     attr_reader :queue

--- a/lib/rabbit_feed/version.rb
+++ b/lib/rabbit_feed/version.rb
@@ -1,3 +1,3 @@
 module RabbitFeed
-  VERSION = '2.3.10'
+  VERSION = '2.4.0'
 end

--- a/spec/fixtures/configuration.yml
+++ b/spec/fixtures/configuration.yml
@@ -1,3 +1,10 @@
+development:
+  host: localhost
+  port: 5672
+  user: guest
+  password: guest
+  application: rabbit_feed
+  auto_delete_queue: false
 test:
   host: localhost
   port: 5672

--- a/spec/lib/rabbit_feed/console_consumer_spec.rb
+++ b/spec/lib/rabbit_feed/console_consumer_spec.rb
@@ -20,7 +20,7 @@ Queue: test\.rabbit_feed_console
 Ready\. Press CTRL\+C to exit\./).to_stdout
       end
 
-      context 'when there are messages on the rabbit_feed_console queue' do
+      context 'when there are events on the rabbit_feed_console queue' do
         let(:queue_depth) { 1 }
 
         it 'asks to purge the queue' do
@@ -32,11 +32,11 @@ Would you like to purge the queue before proceeding\? \(y\/N\)>/).to_stdout
 
     end
 
-    describe 'receiving a message' do
+    describe 'receiving an event' do
       let(:event) { Event.new({name: 'name'},{key: :value}) }
       before { subject.init }
 
-      it 'prints the message' do
+      it 'prints the event' do
         expect{ rabbit_feed_consumer.consume_event event }.to output(
 /-----------------------------------------------name: -----------------------------------------------
 #Event metadata

--- a/spec/lib/rabbit_feed/console_consumer_spec.rb
+++ b/spec/lib/rabbit_feed/console_consumer_spec.rb
@@ -4,9 +4,9 @@ module RabbitFeed
   describe ConsoleConsumer do
     let(:purge) { 'n' }
     let(:queue_depth) { 0 }
-    let(:queue) { double(:queue, queue_depth: queue_depth) }
+    let(:connection) { double(:connection, queue_depth: queue_depth) }
     before do
-      allow(ConsumerConnection).to receive(:instance).and_return(queue)
+      allow(ConsumerConnection).to receive(:instance).and_return(connection)
       allow(STDIN).to receive(:gets).and_return(purge)
     end
 
@@ -33,7 +33,7 @@ Would you like to purge the queue before proceeding\? \(y\/N\)>/).to_stdout
           let(:purge) { 'y' }
 
           it 'purges the queue' do
-            expect(queue).to receive(:purge_queue)
+            expect(connection).to receive(:purge_queue)
             expect{ subject.init }.to output(/Queue purged\./).to_stdout
           end
         end

--- a/spec/lib/rabbit_feed/console_consumer_spec.rb
+++ b/spec/lib/rabbit_feed/console_consumer_spec.rb
@@ -1,13 +1,13 @@
 require 'rabbit_feed/console_consumer'
-require 'rabbit_feed/testing_support/test_rabbit_feed_consumer'
 
 module RabbitFeed
   describe ConsoleConsumer do
+    let(:purge) { 'n' }
     let(:queue_depth) { 0 }
     let(:queue) { double(:queue, queue_depth: queue_depth) }
     before do
       allow(ConsumerConnection).to receive(:instance).and_return(queue)
-      allow(STDIN).to receive(:gets).and_return('n')
+      allow(STDIN).to receive(:gets).and_return(purge)
     end
 
     describe '#init' do
@@ -28,8 +28,16 @@ Ready\. Press CTRL\+C to exit\./).to_stdout
 /There are currently 1 message\(s\) in the console's queue\.
 Would you like to purge the queue before proceeding\? \(y\/N\)>/).to_stdout
         end
-      end
 
+        context 'when the user wishes to purge the queue' do
+          let(:purge) { 'y' }
+
+          it 'purges the queue' do
+            expect(queue).to receive(:purge_queue)
+            expect{ subject.init }.to output(/Queue purged\./).to_stdout
+          end
+        end
+      end
     end
 
     describe 'receiving an event' do

--- a/spec/lib/rabbit_feed/console_consumer_spec.rb
+++ b/spec/lib/rabbit_feed/console_consumer_spec.rb
@@ -1,0 +1,52 @@
+require 'rabbit_feed/console_consumer'
+require 'rabbit_feed/testing_support/test_rabbit_feed_consumer'
+
+module RabbitFeed
+  describe ConsoleConsumer do
+    let(:queue_depth) { 0 }
+    let(:queue) { double(:queue, queue_depth: queue_depth) }
+    before do
+      allow(ConsumerConnection).to receive(:instance).and_return(queue)
+      allow(STDIN).to receive(:gets).and_return('n')
+    end
+
+    describe '#init' do
+
+      it 'prints a welcome message' do
+        expect{ subject.init }.to output(
+/RabbitFeed console starting at .* UTC\.\.\.
+Environment: test
+Queue: test\.rabbit_feed_console
+Ready\. Press CTRL\+C to exit\./).to_stdout
+      end
+
+      context 'when there are messages on the rabbit_feed_console queue' do
+        let(:queue_depth) { 1 }
+
+        it 'asks to purge the queue' do
+          expect{ subject.init }.to output(
+/There are currently 1 message\(s\) in the console's queue\.
+Would you like to purge the queue before proceeding\? \(y\/N\)>/).to_stdout
+        end
+      end
+
+    end
+
+    describe 'receiving a message' do
+      let(:event) { Event.new({name: 'name'},{key: :value}) }
+      before { subject.init }
+
+      it 'prints the message' do
+        expect{ rabbit_feed_consumer.consume_event event }.to output(
+/-----------------------------------------------name: -----------------------------------------------
+#Event metadata
+name: name
+(\*)+
+#Event payload
+key: value
+----------------------------------------------------------------------------------------------------
+1 events received\./).to_stdout
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,8 @@ RSpec.configure do |config|
   end
 
   config.after(connectivity: true) do
-    Thread.kill @consumer_thread if @consumer_thread.present?
+    @consumer_thread.kill if @consumer_thread.present?
+    @consumer_thread.join if @consumer_thread.present?
   end
 
   RabbitFeed::TestingSupport.include_support config

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,7 @@ end
 
 def reset_environment
   RabbitFeed.log                         = RabbitFeed.default_logger
+  RabbitFeed.application                 = nil
   RabbitFeed.environment                 = 'test'
   RabbitFeed.configuration_file_path     = 'spec/fixtures/configuration.yml'
   RabbitFeed.instance_variable_set('@configuration', nil)


### PR DESCRIPTION
@PeterWuMC - I have created a console that publishes RabbitFeed events. Let me know if you think this could be useful!

Sample output:
```
$ be rabbit_feed console --environment development --config spec/fixtures/configuration.yml
RabbitFeed console starting at 2016-02-05 18:03:30 UTC...
Environment: development
Queue: development.rabbit_feed
Ready. Press CTRL+C to exit.
-----------------------------cmm_lead_created: 2016-02-05 18:05:32 UTC-----------------------------
#Event metadata
application: call_me_maybe
created_at_utc: 2016-02-05T18:05:32.032543Z
environment: development
host: macjfleck.int.xbridge.com
name: cmm_lead_created
schema_version: 2.0.0
version: 1.0.0
****************************************************************************************************
#Event payload
alt_telephone_number: 
email_address: xyz1@example.com
full_name: Mr. John Smith
lead_id: 56b4e46c3c4bd42ff6000001
policy_number: 
rfq_reference: XYZ1
telephone_number: 02071234567
----------------------------------------------------------------------------------------------------
```