### PR TITLE
Uses Airbrake sync when consumer_exit_after_fail

### DIFF
--- a/example/non_rails_app/Gemfile.lock
+++ b/example/non_rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.4.0)
+    rabbit_feed (2.4.1)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)

--- a/example/rails_app/Gemfile.lock
+++ b/example/rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.4.0)
+    rabbit_feed (2.4.1)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)

--- a/lib/rabbit_feed.rb
+++ b/lib/rabbit_feed.rb
@@ -38,8 +38,11 @@ module RabbitFeed
         (Airbrake.notify_or_ignore exception) if Airbrake.configuration.public?
       elsif defined?(Airbrake::AIRBRAKE_VERSION) && Airbrake::AIRBRAKE_VERSION.to_i >= 5
         if RabbitFeed.configuration.consumer_exit_after_fail
+          # Will need to send the notification right away, otherwise the `exit` would kill the
+          # Airbrake before the notification is sent out
           Airbrake.notify_sync exception
         else
+          # Airbrake notify default to sending notification asynchronously
           Airbrake.notify exception
         end
       end

--- a/lib/rabbit_feed.rb
+++ b/lib/rabbit_feed.rb
@@ -37,7 +37,11 @@ module RabbitFeed
       if defined?(Airbrake::VERSION) && Airbrake::VERSION.to_i < 5
         (Airbrake.notify_or_ignore exception) if Airbrake.configuration.public?
       elsif defined?(Airbrake::AIRBRAKE_VERSION) && Airbrake::AIRBRAKE_VERSION.to_i >= 5
-        Airbrake.notify exception
+        if RabbitFeed.configuration.consumer_exit_after_fail
+          Airbrake.notify_sync exception
+        else
+          Airbrake.notify exception
+        end
       end
     end
   end

--- a/lib/rabbit_feed/version.rb
+++ b/lib/rabbit_feed/version.rb
@@ -1,3 +1,3 @@
 module RabbitFeed
-  VERSION = '2.4.0'
+  VERSION = '2.4.1'
 end

--- a/spec/lib/rabbit_feed/consumer_connection_spec.rb
+++ b/spec/lib/rabbit_feed/consumer_connection_spec.rb
@@ -121,9 +121,20 @@ module RabbitFeed
                 end
               end
 
-              it 'notifies airbrake' do
-                expect(Airbrake).to receive(:notify).with(an_instance_of RuntimeError)
-                expect{ subject.consume { raise 'Consuming time' } }.not_to raise_error
+              context 'and consumer_exit_after_fail is true' do
+                before { allow(RabbitFeed.configuration).to receive(:consumer_exit_after_fail).and_return(true) }
+                it 'notifies airbrake' do
+                  expect(Airbrake).to receive(:notify_sync).with(an_instance_of RuntimeError)
+                  expect{ subject.consume { raise 'Consuming time' } }.not_to raise_error
+                end
+              end
+
+              context 'and consumer_exit_after_fail is not true' do
+                before { allow(RabbitFeed.configuration).to receive(:consumer_exit_after_fail).and_return(false) }
+                it 'notifies airbrake' do
+                  expect(Airbrake).to receive(:notify).with(an_instance_of RuntimeError)
+                  expect{ subject.consume { raise 'Consuming time' } }.not_to raise_error
+                end
               end
             end
           end

--- a/spec/lib/rabbit_feed/consumer_connection_spec.rb
+++ b/spec/lib/rabbit_feed/consumer_connection_spec.rb
@@ -123,7 +123,7 @@ module RabbitFeed
 
               context 'and consumer_exit_after_fail is true' do
                 before { allow(RabbitFeed.configuration).to receive(:consumer_exit_after_fail).and_return(true) }
-                it 'notifies airbrake' do
+                it 'notifies airbrake synchronously' do
                   expect(Airbrake).to receive(:notify_sync).with(an_instance_of RuntimeError)
                   expect{ subject.consume { raise 'Consuming time' } }.not_to raise_error
                 end


### PR DESCRIPTION
@joshuafleck @makoto

@makoto found a bug that Airbrake did not notify the exception. turn out it was because airbrake uses async by default, and the `exit(1)` killed the process before airbrake can send the exception out.