### PR TITLE
Consumer shutdown signal exception

### DIFF
--- a/example/non_rails_app/Gemfile.lock
+++ b/example/non_rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.4.1)
+    rabbit_feed (2.4.2)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)

--- a/example/rails_app/Gemfile.lock
+++ b/example/rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.4.1)
+    rabbit_feed (2.4.2)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)

--- a/lib/rabbit_feed/consumer_connection.rb
+++ b/lib/rabbit_feed/consumer_connection.rb
@@ -37,7 +37,7 @@ module RabbitFeed
           end
 
           sleep # Sleep indefinitely, as the consumer runs in its own thread
-        rescue SystemExit, Interrupt
+        rescue SystemExit, Interrupt, SignalException
           RabbitFeed.log.info {{ event: :unsubscribe_from_queue, queue: RabbitFeed.configuration.queue }}
         ensure
           (cancel_consumer consumer) if consumer.present?

--- a/lib/rabbit_feed/version.rb
+++ b/lib/rabbit_feed/version.rb
@@ -1,3 +1,3 @@
 module RabbitFeed
-  VERSION = '2.4.1'
+  VERSION = '2.4.2'
 end


### PR DESCRIPTION
@joshuafleck 

As we discussed this morning, it wasnt capturing `SignalException` from `shutdown` command.