### PR TITLE
Clear TestingSupport.published_events when running the spec

### DIFF
--- a/example/non_rails_app/Gemfile.lock
+++ b/example/non_rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.4.2)
+    rabbit_feed (2.4.3)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)
@@ -11,10 +11,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.5.1)
-      activesupport (= 4.2.5.1)
+    activemodel (4.2.6)
+      activesupport (= 4.2.6)
       builder (~> 3.1)
-    activesupport (4.2.5.1)
+    activesupport (4.2.6)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)

--- a/example/rails_app/Gemfile.lock
+++ b/example/rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (2.4.2)
+    rabbit_feed (2.4.3)
       activemodel (>= 3.2.0, < 5.0.0)
       activesupport (>= 3.2.0, < 5.0.0)
       avro (>= 1.5.4, < 1.8.0)

--- a/lib/rabbit_feed/testing_support/rspec_matchers/publish_event.rb
+++ b/lib/rabbit_feed/testing_support/rspec_matchers/publish_event.rb
@@ -16,6 +16,7 @@ module RabbitFeed
           end
 
           begin
+            TestingSupport.published_events.clear
             given_proc.call
           rescue
           end

--- a/lib/rabbit_feed/version.rb
+++ b/lib/rabbit_feed/version.rb
@@ -1,3 +1,3 @@
 module RabbitFeed
-  VERSION = '2.4.2'
+  VERSION = '2.4.3'
 end

--- a/spec/lib/rabbit_feed/testing_support/rspec_matchers/publish_event_spec.rb
+++ b/spec/lib/rabbit_feed/testing_support/rspec_matchers/publish_event_spec.rb
@@ -21,8 +21,20 @@ module RabbitFeed
           end
         end
 
-        context 'when the expectation is met' do
+        it 'clears any existing published_events' do
+          10.times.each do
+            RabbitFeed::Producer.publish_event event_name, event_payload
+          end
 
+          expect do
+            expect {
+              RabbitFeed::Producer.publish_event event_name, event_payload
+            }.to publish_event(event_name, event_payload)
+          end.to change { TestingSupport.published_events.count }.from(10).to(1)
+
+        end
+
+        context 'when the expectation is met' do
           it 'validates' do
             expect {
               RabbitFeed::Producer.publish_event event_name, event_payload


### PR DESCRIPTION
@joshuafleck 

So one thing i found is, esply in feature, when using `expect { something }.to publish(blah)`

it does not just check if `something` published the `blah`. Instead if the previous code published `blah`, and `something` did completely nothing, you spec still pass