### PR TITLE
Do not require custom matcher when not requiring test support

### DIFF
--- a/example/non_rails_app/Gemfile.lock
+++ b/example/non_rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (3.0.1)
+    rabbit_feed (3.0.2)
       activemodel (>= 3.2.0, < 6.0.0)
       activesupport (>= 3.2.0, < 6.0.0)
       avro (>= 1.5.4, < 1.9.0)

--- a/example/rails_app/Gemfile.lock
+++ b/example/rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rabbit_feed (3.0.1)
+    rabbit_feed (3.0.2)
       activemodel (>= 3.2.0, < 6.0.0)
       activesupport (>= 3.2.0, < 6.0.0)
       avro (>= 1.5.4, < 1.9.0)

--- a/lib/rabbit_feed/testing_support.rb
+++ b/lib/rabbit_feed/testing_support.rb
@@ -1,4 +1,3 @@
-require 'rabbit_feed/testing_support/rspec_matchers/publish_event'
 require 'rabbit_feed/testing_support/test_rabbit_feed_consumer'
 require 'rabbit_feed/testing_support/testing_helpers'
 
@@ -9,6 +8,7 @@ module RabbitFeed
     attr_accessor :published_events
 
     def setup(rspec_config)
+      require 'rabbit_feed/testing_support/rspec_matchers/publish_event'
       RabbitFeed.environment ||= 'test'
       capture_published_events rspec_config
       include_support rspec_config

--- a/lib/rabbit_feed/version.rb
+++ b/lib/rabbit_feed/version.rb
@@ -1,3 +1,3 @@
 module RabbitFeed
-  VERSION = '3.0.1'.freeze
+  VERSION = '3.0.2'.freeze
 end

--- a/spec/lib/rabbit_feed/testing_support/rspec_matchers/publish_event_spec.rb
+++ b/spec/lib/rabbit_feed/testing_support/rspec_matchers/publish_event_spec.rb
@@ -1,3 +1,5 @@
+require 'rabbit_feed/testing_support/rspec_matchers/publish_event'
+
 module RabbitFeed
   module TestingSupport
     module RSpecMatchers


### PR DESCRIPTION
This was breaking apps when deployed to an environment where rspec is not installed.