### PR TITLE
Fixup rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,7 +59,7 @@ Style/ClassAndModuleChildren:
     - 'spec/lib/rabbit_feed/consumer_connection_spec.rb'
     - 'spec/lib/rabbit_feed/producer_connection_spec.rb'
 
-Style/FirstParameterIndentation:
+Layout/FirstParameterIndentation:
   Exclude:
     - 'spec/lib/rabbit_feed/console_consumer_spec.rb'
 

--- a/lib/rabbit_feed/client.rb
+++ b/lib/rabbit_feed/client.rb
@@ -16,7 +16,7 @@ module RabbitFeed
 
     attr_reader :command, :options
     validates_presence_of :command, :options
-    validates :command, inclusion: { in: %w[consume produce shutdown console], message: '%{value} is not a valid command' }
+    validates :command, inclusion: { in: %w[consume produce shutdown console], message: '%<value>s is not a valid command' }
     validate :log_file_path_exists
     validate :config_file_exists
     validate :require_path_valid, unless: :console?

--- a/rabbit_feed.gemspec
+++ b/rabbit_feed.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.5'
   spec.add_development_dependency 'rspec-its', '~> 1.2'
-  spec.add_development_dependency 'rubocop', '~> 0.46'
+  spec.add_development_dependency 'rubocop', '~> 0.49.1'
   spec.add_development_dependency 'rutabaga', '~> 2.1'
   spec.add_development_dependency 'simplecov', '~> 0.12'
   spec.add_development_dependency 'timecop', '~> 0.8'


### PR DESCRIPTION
Fixes the issue where CI is pulling a newer version of Rubocop and causing CI failures due to Rubocop discovering new issues due to the upgrade.

Should resolve the issues documented here @dncrht https://github.com/simplybusiness/rabbit_feed/pull/54#issuecomment-307118355