### PR TITLE
Update rabbit feed to allow handling of us events

### DIFF
--- a/lib/rabbit_feed/producer.rb
+++ b/lib/rabbit_feed/producer.rb
@@ -4,7 +4,7 @@ module RabbitFeed
 
     attr_accessor :event_definitions
 
-    def publish_event(name, payload, application=RabbitFeed.configuration.application)
+    def publish_event(name, payload, application = RabbitFeed.configuration.application)
       raise RabbitFeed::Error, 'Unable to publish event. No event definitions set.' unless event_definitions.present?
       (event_definition = event_definitions[name]) || (raise RabbitFeed::Error, "definition for event: #{name} not found")
       timestamp         = Time.now.utc

--- a/spec/lib/rabbit_feed/producer_spec.rb
+++ b/spec/lib/rabbit_feed/producer_spec.rb
@@ -109,7 +109,7 @@ module RabbitFeed
         expect(ProducerConnection.instance).to receive(:publish) do |_, options|
           expect(options[:app_id]).to eq app_name
         end
-        RabbitFeed::Producer.publish_event(event_name, {'field' => 'value'}, app_name)
+        RabbitFeed::Producer.publish_event(event_name, { 'field' => 'value' }, app_name)
       end
     end
   end

--- a/spec/lib/rabbit_feed/producer_spec.rb
+++ b/spec/lib/rabbit_feed/producer_spec.rb
@@ -106,7 +106,7 @@ module RabbitFeed
       end
 
       it 'uses the application given passed in as an argument' do
-        expect(ProducerConnection.instance).to receive(:publish) do |x, options|
+        expect(ProducerConnection.instance).to receive(:publish) do |_, options|
           expect(options[:app_id]).to eq app_name
         end
         RabbitFeed::Producer.publish_event(event_name, {'field' => 'value'}, app_name)

--- a/spec/lib/rabbit_feed/producer_spec.rb
+++ b/spec/lib/rabbit_feed/producer_spec.rb
@@ -83,6 +83,7 @@ module RabbitFeed
 
     describe '.publish_event' do
       let(:event_name) { 'event_name' }
+      let(:app_name) { 'Some_application_name' }
       before do
         allow(RabbitFeed::ProducerConnection).to receive(:publish)
         EventDefinitions do
@@ -105,7 +106,6 @@ module RabbitFeed
       end
 
       it 'uses the application given passed in as an argument' do
-        app_name = "another_application_name"
         expect(ProducerConnection.instance).to receive(:publish) do |x, options|
           expect(options[:app_id]).to eq app_name
         end

--- a/spec/lib/rabbit_feed/producer_spec.rb
+++ b/spec/lib/rabbit_feed/producer_spec.rb
@@ -80,5 +80,37 @@ module RabbitFeed
         end
       end
     end
+
+    describe '.publish_event' do
+      let(:event_name) { 'event_name' }
+      before do
+        allow(RabbitFeed::ProducerConnection).to receive(:publish)
+        EventDefinitions do
+          define_event('event_name', version: '1.0.0') do
+            defined_as do
+              'The definition of the event'
+            end
+            payload_contains do
+              field('field', type: 'string', definition: 'The definition of the field', sensitive: true)
+            end
+          end
+        end
+      end
+
+      it 'uses the default application found in RabbitFeed.configuration.application if no application argument is given' do
+        expect(ProducerConnection.instance).to receive(:publish) do |_, options|
+          expect(options[:app_id]).to eq 'rabbit_feed'
+        end
+        RabbitFeed::Producer.publish_event event_name, 'field' => 'value'
+      end
+
+      it 'uses the application given passed in as an argument' do
+        app_name = "another_application_name"
+        expect(ProducerConnection.instance).to receive(:publish) do |x, options|
+          expect(options[:app_id]).to eq app_name
+        end
+        RabbitFeed::Producer.publish_event(event_name, {'field' => 'value'}, app_name)
+      end
+    end
   end
 end


### PR DESCRIPTION
We need the ability to specify another application name so that we can send events to DNA from the US site.